### PR TITLE
Perf/theme effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.claude

--- a/src/components/TerminalUI.tsx
+++ b/src/components/TerminalUI.tsx
@@ -74,12 +74,10 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
     const isMobile = useIsMobile();
 
     // 仅这些主题仍通过 React state 消费鼠标坐标；
-    // 已迁移到 ref 直写 transform 的主题（Origin、Miku）不再触发逐帧重渲染
+    // 已迁移到 ref 直写 transform 的主题（Origin、Tactical、Miku）不再触发逐帧重渲染
     const needsMousePos =
         !isMobile &&
-        (theme === ThemePreset.TACTICAL ||
-            theme === ThemePreset.INDUSTRIAL ||
-            theme === ThemePreset.AZURE);
+        (theme === ThemePreset.INDUSTRIAL || theme === ThemePreset.AZURE);
 
     useEffect(() => {
         if (!needsMousePos) return;
@@ -102,7 +100,7 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
         case ThemePreset.ORIGIN:
             return <OriginForeground />;
         case ThemePreset.TACTICAL:
-            return <TacticalForeground mousePos={mousePos} />;
+            return <TacticalForeground />;
         case ThemePreset.ABYSSAL:
             return <AbyssalForeground />;
         case ThemePreset.INDUSTRIAL:

--- a/src/components/TerminalUI.tsx
+++ b/src/components/TerminalUI.tsx
@@ -84,17 +84,14 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
     useEffect(() => {
         if (!needsMousePos) return;
 
-        let animationFrameId: number;
+        // 同步 setState：浏览器按帧节奏合并派发 mousemove（每帧至多一次），
+        // 经 rAF 转发可能多等一帧，表现为光标跟随延迟
         const handleMouseMove = (e: MouseEvent) => {
-            cancelAnimationFrame(animationFrameId);
-            animationFrameId = requestAnimationFrame(() => {
-                setMousePos({ x: e.clientX, y: e.clientY });
-            });
+            setMousePos({ x: e.clientX, y: e.clientY });
         };
         window.addEventListener("mousemove", handleMouseMove);
         return () => {
             window.removeEventListener("mousemove", handleMouseMove);
-            cancelAnimationFrame(animationFrameId);
         };
     }, [needsMousePos]);
 

--- a/src/components/TerminalUI.tsx
+++ b/src/components/TerminalUI.tsx
@@ -73,8 +73,16 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
     const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
     const isMobile = useIsMobile();
 
+    // 仅这些主题仍通过 React state 消费鼠标坐标；
+    // 已迁移到 ref 直写 transform 的主题（Origin、Miku）不再触发逐帧重渲染
+    const needsMousePos =
+        !isMobile &&
+        (theme === ThemePreset.TACTICAL ||
+            theme === ThemePreset.INDUSTRIAL ||
+            theme === ThemePreset.AZURE);
+
     useEffect(() => {
-        if (isMobile) return;
+        if (!needsMousePos) return;
 
         let animationFrameId: number;
         const handleMouseMove = (e: MouseEvent) => {
@@ -88,14 +96,14 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
             window.removeEventListener("mousemove", handleMouseMove);
             cancelAnimationFrame(animationFrameId);
         };
-    }, [isMobile]);
+    }, [needsMousePos]);
 
     // 移动端不渲染鼠标交互层
     if (isMobile) return null;
 
     switch (theme) {
         case ThemePreset.ORIGIN:
-            return <OriginForeground mousePos={mousePos} />;
+            return <OriginForeground />;
         case ThemePreset.TACTICAL:
             return <TacticalForeground mousePos={mousePos} />;
         case ThemePreset.ABYSSAL:

--- a/src/components/TerminalUI.tsx
+++ b/src/components/TerminalUI.tsx
@@ -73,11 +73,9 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
     const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
     const isMobile = useIsMobile();
 
-    // 仅这些主题仍通过 React state 消费鼠标坐标；
-    // 已迁移到 ref 直写 transform 的主题（Origin、Tactical、Miku）不再触发逐帧重渲染
-    const needsMousePos =
-        !isMobile &&
-        (theme === ThemePreset.INDUSTRIAL || theme === ThemePreset.AZURE);
+    // 仅 INDUSTRIAL 仍通过 React state 消费鼠标坐标；
+    // 其余鼠标主题均已迁移到 ref 直写 transform，不再触发逐帧重渲染
+    const needsMousePos = !isMobile && theme === ThemePreset.INDUSTRIAL;
 
     useEffect(() => {
         if (!needsMousePos) return;
@@ -106,7 +104,7 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
         case ThemePreset.INDUSTRIAL:
             return <IndustrialForeground mousePos={mousePos} />;
         case ThemePreset.AZURE:
-            return <AzureForeground mousePos={mousePos} />;
+            return <AzureForeground />;
         case ThemePreset.MIKU:
             return <MikuForegroundLayer />;
         default:

--- a/src/components/TerminalUI.tsx
+++ b/src/components/TerminalUI.tsx
@@ -4,7 +4,7 @@
  * 负责根据当前主题渲染对应的背景和前景效果
  * 主题效果组件位于 ./themes/ 目录
  */
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { ThemePreset } from "../types";
 // 主题效果
@@ -70,30 +70,13 @@ export const BackgroundLayer: React.FC<{ theme?: ThemePreset }> = ({
 export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
     theme = ThemePreset.ORIGIN,
 }) => {
-    const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
     const isMobile = useIsMobile();
-
-    // 仅 INDUSTRIAL 仍通过 React state 消费鼠标坐标；
-    // 其余鼠标主题均已迁移到 ref 直写 transform，不再触发逐帧重渲染
-    const needsMousePos = !isMobile && theme === ThemePreset.INDUSTRIAL;
-
-    useEffect(() => {
-        if (!needsMousePos) return;
-
-        // 同步 setState：浏览器按帧节奏合并派发 mousemove（每帧至多一次），
-        // 经 rAF 转发可能多等一帧，表现为光标跟随延迟
-        const handleMouseMove = (e: MouseEvent) => {
-            setMousePos({ x: e.clientX, y: e.clientY });
-        };
-        window.addEventListener("mousemove", handleMouseMove);
-        return () => {
-            window.removeEventListener("mousemove", handleMouseMove);
-        };
-    }, [needsMousePos]);
 
     // 移动端不渲染鼠标交互层
     if (isMobile) return null;
 
+    // 所有鼠标跟随主题均在组件内部以 ref 直写 transform 跟踪光标，
+    // 不再经由 React state 逐帧重渲染
     switch (theme) {
         case ThemePreset.ORIGIN:
             return <OriginForeground />;
@@ -102,7 +85,7 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
         case ThemePreset.ABYSSAL:
             return <AbyssalForeground />;
         case ThemePreset.INDUSTRIAL:
-            return <IndustrialForeground mousePos={mousePos} />;
+            return <IndustrialForeground />;
         case ThemePreset.AZURE:
             return <AzureForeground />;
         case ThemePreset.MIKU:

--- a/src/components/themes/BackgroundEffects.tsx
+++ b/src/components/themes/BackgroundEffects.tsx
@@ -39,9 +39,9 @@ export const AbyssalGrid = () => (
 export const NeonGrid = () => (
     <>
         <style>{`
-            @keyframes neon-grid-move {
-                0% { background-position: 0 0, 0 0, 0 0; }
-                100% { background-position: 0 0, 0 40px, 0 0; }
+            @keyframes neon-grid-scroll {
+                0% { transform: translateY(0); }
+                100% { transform: translateY(40px); }
             }
             .synthwave-sun {
                 background: linear-gradient(180deg, #ffe53b 0%, #ff9800 45%, #ff5722 75%, #e91e63 100%);
@@ -86,18 +86,49 @@ export const NeonGrid = () => (
             <div className="absolute inset-[-20%] rounded-full bg-[#ff5722] opacity-30 blur-[70px]" />
         </div>
 
+        {/*
+          性能优化：原实现用 background-position 关键帧滚动水平网格线，
+          每帧触发整层重绘。现拆为三层（视觉与原 multi-background 完全一致，
+          叠放顺序 = 原 background 列表的倒序）：静态竖线层、滚动横线层
+          （transform 平移一个 40px 纹理周期，纯合成器动画）、静态渐隐层。
+        */}
         <div
-            className="absolute inset-0 opacity-20 pointer-events-none"
+            className="absolute inset-0 opacity-20 pointer-events-none overflow-hidden"
             style={{
-                background:
-                    "linear-gradient(transparent 0%, var(--color-base) 100%), linear-gradient(0deg, var(--color-primary) 1px, transparent 1px), linear-gradient(90deg, var(--color-primary) 1px, transparent 1px)",
-                backgroundSize: "100% 100%, 40px 40px, 40px 40px",
                 transform:
                     "perspective(500px) rotateX(60deg) translateY(100px) translateZ(-100px)",
                 transformOrigin: "bottom",
-                animation: "neon-grid-move 1.5s linear infinite",
             }}
-        ></div>
+        >
+            {/* 竖线（静态） */}
+            <div
+                className="absolute inset-0"
+                style={{
+                    backgroundImage:
+                        "linear-gradient(90deg, var(--color-primary) 1px, transparent 1px)",
+                    backgroundSize: "40px 40px",
+                }}
+            ></div>
+            {/* 横线（向下滚动；上方外扩一个 40px 纹理周期避免露缝，溢出由父级裁剪） */}
+            <div
+                className="absolute left-0 right-0 bottom-0"
+                style={{
+                    top: "-40px",
+                    backgroundImage:
+                        "linear-gradient(0deg, var(--color-primary) 1px, transparent 1px)",
+                    backgroundSize: "40px 40px",
+                    animation: "neon-grid-scroll 1.5s linear infinite",
+                }}
+            ></div>
+            {/* 顶部渐隐遮罩（静态，原 background 列表首层） */}
+            <div
+                className="absolute inset-0"
+                style={{
+                    background:
+                        "linear-gradient(transparent 0%, var(--color-base) 100%)",
+                }}
+            ></div>
+        </div>
 
         <div className="absolute top-0 w-full h-full bg-gradient-to-b from-theme-base via-transparent to-theme-primary/10 pointer-events-none"></div>
         <div className="absolute bottom-0 left-0 right-0 h-40 bg-theme-primary/20 blur-[100px] pointer-events-none"></div>

--- a/src/components/themes/ForegroundEffects.tsx
+++ b/src/components/themes/ForegroundEffects.tsx
@@ -75,11 +75,15 @@ export const TacticalForeground: React.FC<{ mousePos: MousePos }> = ({
 
 /**
  * Abyssal 主题前景效果 - 扫描线
+ *
+ * 性能优化：原 keyframes 动画 top（每帧触发布局+重绘，叠加 blur 滤镜成本），
+ * 改为 transform 平移（纯合成器动画）。容器为 fixed inset-0（桌面端等于视口），
+ * translateY(100vh) 与 top: 100% 终点一致，时序/缓动/透明度不变。
  */
 export const AbyssalForeground: React.FC = () => (
     <div className="fixed inset-0 pointer-events-none z-50">
         <div className="absolute top-0 left-0 w-full h-[5px] bg-theme-primary/20 blur-sm animate-[scan_3s_ease-in-out_infinite]"></div>
-        <style>{`@keyframes scan { 0% { top: 0; opacity: 0; } 50% { opacity: 1; } 100% { top: 100%; opacity: 0; } }`}</style>
+        <style>{`@keyframes scan { 0% { transform: translateY(0); opacity: 0; } 50% { opacity: 1; } 100% { transform: translateY(100vh); opacity: 0; } }`}</style>
     </div>
 );
 
@@ -137,6 +141,7 @@ export const AzureForeground: React.FC<{ mousePos: MousePos }> = ({
             <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 -left-4"></div>
             <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 left-0"></div>
         </div>
-        <style>{`@keyframes scan { 0% { top: 0; opacity: 0; } 50% { opacity: 1; } 100% { top: 100%; opacity: 0; } }`}</style>
+        {/* 扫描线 keyframes：同 Abyssal，top 布局动画改为合成器 transform */}
+        <style>{`@keyframes scan { 0% { transform: translateY(0); opacity: 0; } 50% { opacity: 1; } 100% { transform: translateY(100vh); opacity: 0; } }`}</style>
     </div>
 );

--- a/src/components/themes/ForegroundEffects.tsx
+++ b/src/components/themes/ForegroundEffects.tsx
@@ -1,25 +1,59 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 interface MousePos {
     x: number;
     y: number;
 }
 
+// Origin 光晕半径（与原 radial-gradient 的 circle 400px 一致）
+const ORIGIN_GLOW_RADIUS = 400;
+
 /**
  * Origin 主题前景效果 - 鼠标光晕
+ *
+ * 性能优化：原实现把鼠标坐标写进 radial-gradient 的圆心，
+ * 每次移动都重新生成渐变并整层重绘。现改为渐变只光栅化一次
+ * （固定尺寸贴图、圆心居中），鼠标移动时经 ref 直写 transform
+ * 平移贴图（纯合成器操作，不经 React 重渲染）。渐变参数不变，
+ * 初始位置同原实现（圆心在视口原点），视觉完全一致。
  */
-export const OriginForeground: React.FC<{ mousePos: MousePos }> = ({
-    mousePos,
-}) => (
-    <div className="fixed inset-0 pointer-events-none z-50 mix-blend-screen">
-        <div
-            className="absolute inset-0 transition-opacity duration-300"
-            style={{
-                background: `radial-gradient(circle 400px at ${mousePos.x}px ${mousePos.y}px, color-mix(in srgb, var(--color-primary) 15%, transparent), transparent 70%)`,
-            }}
-        ></div>
-    </div>
-);
+export const OriginForeground: React.FC = () => {
+    const glowRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        let frameId: number;
+        const handleMouseMove = (e: MouseEvent) => {
+            const x = e.clientX;
+            const y = e.clientY;
+            cancelAnimationFrame(frameId);
+            frameId = requestAnimationFrame(() => {
+                if (glowRef.current) {
+                    glowRef.current.style.transform = `translate3d(${x - ORIGIN_GLOW_RADIUS}px, ${y - ORIGIN_GLOW_RADIUS}px, 0)`;
+                }
+            });
+        };
+        window.addEventListener("mousemove", handleMouseMove);
+        return () => {
+            window.removeEventListener("mousemove", handleMouseMove);
+            cancelAnimationFrame(frameId);
+        };
+    }, []);
+
+    return (
+        <div className="fixed inset-0 pointer-events-none z-50 mix-blend-screen overflow-hidden">
+            <div
+                ref={glowRef}
+                className="absolute top-0 left-0 transition-opacity duration-300 will-change-transform"
+                style={{
+                    width: `${ORIGIN_GLOW_RADIUS * 2}px`,
+                    height: `${ORIGIN_GLOW_RADIUS * 2}px`,
+                    transform: `translate3d(${-ORIGIN_GLOW_RADIUS}px, ${-ORIGIN_GLOW_RADIUS}px, 0)`,
+                    background: `radial-gradient(circle ${ORIGIN_GLOW_RADIUS}px at center, color-mix(in srgb, var(--color-primary) 15%, transparent), transparent 70%)`,
+                }}
+            ></div>
+        </div>
+    );
+};
 
 /**
  * Tactical 主题前景效果 - 十字准星

--- a/src/components/themes/ForegroundEffects.tsx
+++ b/src/components/themes/ForegroundEffects.tsx
@@ -21,21 +21,16 @@ export const OriginForeground: React.FC = () => {
     const glowRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        let frameId: number;
+        // 同步直写 transform：浏览器本身按帧节奏合并派发 mousemove，
+        // 再经 rAF 转发反而可能多等一帧；样式写入不触发布局，开销极低
         const handleMouseMove = (e: MouseEvent) => {
-            const x = e.clientX;
-            const y = e.clientY;
-            cancelAnimationFrame(frameId);
-            frameId = requestAnimationFrame(() => {
-                if (glowRef.current) {
-                    glowRef.current.style.transform = `translate3d(${x - ORIGIN_GLOW_RADIUS}px, ${y - ORIGIN_GLOW_RADIUS}px, 0)`;
-                }
-            });
+            if (glowRef.current) {
+                glowRef.current.style.transform = `translate3d(${e.clientX - ORIGIN_GLOW_RADIUS}px, ${e.clientY - ORIGIN_GLOW_RADIUS}px, 0)`;
+            }
         };
         window.addEventListener("mousemove", handleMouseMove);
         return () => {
             window.removeEventListener("mousemove", handleMouseMove);
-            cancelAnimationFrame(frameId);
         };
     }, []);
 

--- a/src/components/themes/ForegroundEffects.tsx
+++ b/src/components/themes/ForegroundEffects.tsx
@@ -146,32 +146,64 @@ export const IndustrialForeground: React.FC<{ mousePos: MousePos }> = ({
     </div>
 );
 
+// Azure 聚光灯半径（与原 radial-gradient 的 circle 300px 一致）
+const AZURE_SPOT_RADIUS = 300;
+
 /**
  * Azure 主题前景效果 - 分析聚光灯
+ *
+ * 性能优化：聚光灯渐变原先把鼠标坐标写进圆心、每帧重新生成并整层重绘，
+ * 改为固定 600x600 贴图（渐变参数不变，opacity/mix-blend-mode 原样保留，
+ * 贴图覆盖范围外原本就是全透明，混合结果不变）+ ref 直写 transform 跟随；
+ * 角标准星同样由 ref 直写。两者均为纯合成器操作，不再经 React 逐帧重渲染。
  */
-export const AzureForeground: React.FC<{ mousePos: MousePos }> = ({
-    mousePos,
-}) => (
-    <div className="fixed inset-0 pointer-events-none z-50">
-        <div className="absolute top-0 left-0 w-full h-[3px] bg-theme-primary/30 blur-[2px] animate-[scan_3s_ease-in-out_infinite]"></div>
-        <div
-            className="absolute inset-0"
-            style={{
-                background: `radial-gradient(circle 300px at ${mousePos.x}px ${mousePos.y}px, var(--color-primary), transparent 70%)`,
-                opacity: 0.08,
-                mixBlendMode: "overlay",
-            }}
-        ></div>
-        <div
-            className="absolute top-0 left-0 will-change-transform"
-            style={{ transform: `translate(${mousePos.x}px, ${mousePos.y}px)` }}
-        >
-            <div className="w-[1px] h-4 bg-theme-primary/30 absolute -top-4 left-0"></div>
-            <div className="w-[1px] h-4 bg-theme-primary/30 absolute top-0 left-0"></div>
-            <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 -left-4"></div>
-            <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 left-0"></div>
+export const AzureForeground: React.FC = () => {
+    const spotlightRef = useRef<HTMLDivElement>(null);
+    const reticleRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        // 同步直写：浏览器按帧节奏合并派发 mousemove，无需 rAF 转发
+        const handleMouseMove = (e: MouseEvent) => {
+            if (spotlightRef.current) {
+                spotlightRef.current.style.transform = `translate3d(${e.clientX - AZURE_SPOT_RADIUS}px, ${e.clientY - AZURE_SPOT_RADIUS}px, 0)`;
+            }
+            if (reticleRef.current) {
+                reticleRef.current.style.transform = `translate3d(${e.clientX}px, ${e.clientY}px, 0)`;
+            }
+        };
+        window.addEventListener("mousemove", handleMouseMove);
+        return () => {
+            window.removeEventListener("mousemove", handleMouseMove);
+        };
+    }, []);
+
+    return (
+        <div className="fixed inset-0 pointer-events-none z-50 overflow-hidden">
+            <div className="absolute top-0 left-0 w-full h-[3px] bg-theme-primary/30 blur-[2px] animate-[scan_3s_ease-in-out_infinite]"></div>
+            <div
+                ref={spotlightRef}
+                className="absolute top-0 left-0 will-change-transform"
+                style={{
+                    width: `${AZURE_SPOT_RADIUS * 2}px`,
+                    height: `${AZURE_SPOT_RADIUS * 2}px`,
+                    transform: `translate3d(${-AZURE_SPOT_RADIUS}px, ${-AZURE_SPOT_RADIUS}px, 0)`,
+                    background: `radial-gradient(circle ${AZURE_SPOT_RADIUS}px at center, var(--color-primary), transparent 70%)`,
+                    opacity: 0.08,
+                    mixBlendMode: "overlay",
+                }}
+            ></div>
+            <div
+                ref={reticleRef}
+                className="absolute top-0 left-0 will-change-transform"
+                style={{ transform: "translate3d(0px, 0px, 0)" }}
+            >
+                <div className="w-[1px] h-4 bg-theme-primary/30 absolute -top-4 left-0"></div>
+                <div className="w-[1px] h-4 bg-theme-primary/30 absolute top-0 left-0"></div>
+                <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 -left-4"></div>
+                <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 left-0"></div>
+            </div>
+            {/* 扫描线 keyframes：同 Abyssal，top 布局动画改为合成器 transform */}
+            <style>{`@keyframes scan { 0% { transform: translateY(0); opacity: 0; } 50% { opacity: 1; } 100% { transform: translateY(100vh); opacity: 0; } }`}</style>
         </div>
-        {/* 扫描线 keyframes：同 Abyssal，top 布局动画改为合成器 transform */}
-        <style>{`@keyframes scan { 0% { transform: translateY(0); opacity: 0; } 50% { opacity: 1; } 100% { transform: translateY(100vh); opacity: 0; } }`}</style>
-    </div>
-);
+    );
+};

--- a/src/components/themes/ForegroundEffects.tsx
+++ b/src/components/themes/ForegroundEffects.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect, useRef } from "react";
 
-interface MousePos {
-    x: number;
-    y: number;
-}
-
 // Origin 光晕半径（与原 radial-gradient 的 circle 400px 一致）
 const ORIGIN_GLOW_RADIUS = 400;
 
@@ -117,34 +112,56 @@ export const AbyssalForeground: React.FC = () => (
     </div>
 );
 
+// Industrial 警告圈半径（容器 200x200，圆心对准光标）
+const INDUSTRIAL_RING_RADIUS = 100;
+
 /**
  * Industrial 主题前景效果 - 警告圆圈
+ *
+ * 性能优化：transform 定位原本就正确，但仍经 React state 逐帧重渲染，
+ * 改为 ref 直写 transform（与其他主题一致），不再触发渲染。
  */
-export const IndustrialForeground: React.FC<{ mousePos: MousePos }> = ({
-    mousePos,
-}) => (
-    <div className="fixed inset-0 pointer-events-none z-50">
-        <div
-            className="absolute top-0 left-0 will-change-transform"
-            style={{
-                transform: `translate(${mousePos.x - 100}px, ${mousePos.y - 100}px)`,
-                width: "200px",
-                height: "200px",
-            }}
-        >
-            <div className="w-full h-full border-4 border-theme-primary/20 rounded-full animate-ping-slow"></div>
-            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-8 h-8 border-2 border-theme-primary/40 rounded-sm rotate-45"></div>
+export const IndustrialForeground: React.FC = () => {
+    const ringRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        // 同步直写：浏览器按帧节奏合并派发 mousemove，无需 rAF 转发
+        const handleMouseMove = (e: MouseEvent) => {
+            if (ringRef.current) {
+                ringRef.current.style.transform = `translate3d(${e.clientX - INDUSTRIAL_RING_RADIUS}px, ${e.clientY - INDUSTRIAL_RING_RADIUS}px, 0)`;
+            }
+        };
+        window.addEventListener("mousemove", handleMouseMove);
+        return () => {
+            window.removeEventListener("mousemove", handleMouseMove);
+        };
+    }, []);
+
+    return (
+        <div className="fixed inset-0 pointer-events-none z-50">
+            <div
+                ref={ringRef}
+                className="absolute top-0 left-0 will-change-transform"
+                style={{
+                    transform: `translate3d(${-INDUSTRIAL_RING_RADIUS}px, ${-INDUSTRIAL_RING_RADIUS}px, 0)`,
+                    width: `${INDUSTRIAL_RING_RADIUS * 2}px`,
+                    height: `${INDUSTRIAL_RING_RADIUS * 2}px`,
+                }}
+            >
+                <div className="w-full h-full border-4 border-theme-primary/20 rounded-full animate-ping-slow"></div>
+                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-8 h-8 border-2 border-theme-primary/40 rounded-sm rotate-45"></div>
+            </div>
+            <div
+                className="absolute inset-0 opacity-[0.02]"
+                style={{
+                    backgroundImage:
+                        "repeating-linear-gradient(45deg, var(--color-primary) 0, var(--color-primary) 2px, transparent 0, transparent 20px)",
+                    backgroundSize: "40px 40px",
+                }}
+            ></div>
         </div>
-        <div
-            className="absolute inset-0 opacity-[0.02]"
-            style={{
-                backgroundImage:
-                    "repeating-linear-gradient(45deg, var(--color-primary) 0, var(--color-primary) 2px, transparent 0, transparent 20px)",
-                backgroundSize: "40px 40px",
-            }}
-        ></div>
-    </div>
-);
+    );
+};
 
 // Azure 聚光灯半径（与原 radial-gradient 的 circle 300px 一致）
 const AZURE_SPOT_RADIUS = 300;

--- a/src/components/themes/ForegroundEffects.tsx
+++ b/src/components/themes/ForegroundEffects.tsx
@@ -52,26 +52,56 @@ export const OriginForeground: React.FC = () => {
 
 /**
  * Tactical 主题前景效果 - 十字准星
+ *
+ * 性能优化：原实现用 left/top 定位（每帧布局重排）并经 React state 逐帧重渲染，
+ * 改为 ref 直写 transform 平移（纯合成器）、坐标文本直写 textContent。
+ * 原 className 里的 transition-transform duration-75 是死代码（移动走 left/top，
+ * transform 从未变化、过渡从未触发），迁移后已删除以保持"瞬时跟随"的原有行为。
  */
-export const TacticalForeground: React.FC<{ mousePos: MousePos }> = ({
-    mousePos,
-}) => (
-    <div className="fixed inset-0 pointer-events-none z-50">
-        <div
-            className="absolute transform -translate-x-1/2 -translate-y-1/2 transition-transform duration-75 ease-out"
-            style={{ left: mousePos.x, top: mousePos.y }}
-        >
-            <div className="w-[100vw] h-[1px] bg-theme-primary/10 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
-            <div className="w-[1px] h-[100vh] bg-theme-primary/10 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
-            <div className="w-12 h-12 border border-theme-primary/50 rounded-full flex items-center justify-center">
-                <div className="w-1 h-1 bg-theme-primary"></div>
+export const TacticalForeground: React.FC = () => {
+    const crosshairRef = useRef<HTMLDivElement>(null);
+    const coordsRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        // 同步直写：浏览器按帧节奏合并派发 mousemove，无需 rAF 转发
+        const handleMouseMove = (e: MouseEvent) => {
+            if (crosshairRef.current) {
+                crosshairRef.current.style.transform = `translate3d(${e.clientX}px, ${e.clientY}px, 0) translate(-50%, -50%)`;
+            }
+            if (coordsRef.current) {
+                coordsRef.current.textContent = `TARGET_COORDS: [${e.clientX}, ${e.clientY}]`;
+            }
+        };
+        window.addEventListener("mousemove", handleMouseMove);
+        return () => {
+            window.removeEventListener("mousemove", handleMouseMove);
+        };
+    }, []);
+
+    return (
+        <div className="fixed inset-0 pointer-events-none z-50">
+            <div
+                ref={crosshairRef}
+                className="absolute top-0 left-0 will-change-transform"
+                style={{
+                    transform: "translate3d(0px, 0px, 0) translate(-50%, -50%)",
+                }}
+            >
+                <div className="w-[100vw] h-[1px] bg-theme-primary/10 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
+                <div className="w-[1px] h-[100vh] bg-theme-primary/10 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
+                <div className="w-12 h-12 border border-theme-primary/50 rounded-full flex items-center justify-center">
+                    <div className="w-1 h-1 bg-theme-primary"></div>
+                </div>
+            </div>
+            <div
+                ref={coordsRef}
+                className="absolute bottom-4 right-4 font-ui-mono text-ui-micro text-theme-primary/70"
+            >
+                TARGET_COORDS: [0, 0]
             </div>
         </div>
-        <div className="absolute bottom-4 right-4 font-ui-mono text-ui-micro text-theme-primary/70">
-            TARGET_COORDS: [{mousePos.x}, {mousePos.y}]
-        </div>
-    </div>
-);
+    );
+};
 
 /**
  * Abyssal 主题前景效果 - 扫描线

--- a/src/components/themes/MikuDecorations.tsx
+++ b/src/components/themes/MikuDecorations.tsx
@@ -15,28 +15,22 @@ const MikuHexPattern: React.FC = () => {
     React.useEffect(() => {
         if (isMobile) return;
 
-        let animationFrameId: number;
-        let x = -1000;
-        let y = -1000;
         const radius = 180;
 
+        // 同步直写 transform：浏览器按帧节奏合并派发 mousemove，
+        // 经 rAF 转发可能多等一帧，表现为光标跟随延迟
         const handleMouseMove = (e: MouseEvent) => {
-            x = e.clientX;
-            y = e.clientY;
-
-            cancelAnimationFrame(animationFrameId);
-            animationFrameId = requestAnimationFrame(() => {
-                if (outerRef.current && innerRef.current) {
-                    outerRef.current.style.transform = `translate3d(${x - radius}px, ${y - radius}px, 0)`;
-                    innerRef.current.style.transform = `translate3d(${-(x - radius)}px, ${-(y - radius)}px, 0)`;
-                }
-            });
+            if (outerRef.current && innerRef.current) {
+                const x = e.clientX - radius;
+                const y = e.clientY - radius;
+                outerRef.current.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+                innerRef.current.style.transform = `translate3d(${-x}px, ${-y}px, 0)`;
+            }
         };
 
         window.addEventListener("mousemove", handleMouseMove);
         return () => {
             window.removeEventListener("mousemove", handleMouseMove);
-            cancelAnimationFrame(animationFrameId);
         };
     }, [isMobile]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -283,24 +283,39 @@ body {
   border-color: color-mix(in srgb, var(--color-primary) 40%, transparent);
 }
 
-/* 数据流动画 */
+/* 数据流动画
+   性能优化：原先在元素自身滚动 background-position（每帧重绘），
+   改为伪元素承载同一渐变纹理（周期 = 2 倍容器宽，与原 background-size 200% 一致），
+   transform 平移一个周期（自身 400% 宽的 -50% = -2 倍容器宽，
+   方向、速度、相位均与原实现相同），纯合成器动画。 */
 @keyframes data-flow {
   0% {
-    background-position: 0% 0%;
+    transform: translateX(0);
   }
 
   100% {
-    background-position: 200% 0%;
+    transform: translateX(-50%);
   }
 }
 
 .data-flow-bg {
+  overflow: hidden;
+}
+
+.data-flow-bg::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 400%;
   background: linear-gradient(90deg,
       transparent 0%,
       color-mix(in srgb, var(--color-primary) 10%, transparent) 50%,
       transparent 100%);
-  background-size: 200% 100%;
+  background-size: 50% 100%;
   animation: data-flow 3s linear infinite;
+  will-change: transform;
 }
 
 @keyframes spin-slow-linear {

--- a/src/index.css
+++ b/src/index.css
@@ -314,8 +314,8 @@ body {
       color-mix(in srgb, var(--color-primary) 10%, transparent) 50%,
       transparent 100%);
   background-size: 50% 100%;
+  /* 无需 will-change：infinite transform 动画运行期间元素本就持有独立合成层 */
   animation: data-flow 3s linear infinite;
-  will-change: transform;
 }
 
 @keyframes spin-slow-linear {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shifts theme effects and the data-flow banner to compositor transforms, removes React per-frame mouse tracking and rAF hops, and drops redundant will-change. Smoother cursor effects and lower CPU/GPU use with no visual changes.

- **Refactors**
  - Origin, Tactical, Industrial, Azure, and Miku hex now follow the cursor via ref-written `translate3d`; removed ForegroundLayer mouse state; Tactical coords update via `textContent`.
  - Neon grid rebuilt into three layers (static verticals, transform-scrolled horizontals, static fade) with overflow-hidden to prevent seams.
  - Abyssal/Azure scan lines animate via `transform: translateY` instead of `top`.
  - Data-flow banner uses a `::before` texture animated with `transform`; removed redundant `will-change` on the pseudo-element and kept it only on JS-driven mouse followers.
  - Add `.claude` to `.gitignore`.

<sup>Written for commit 1b220a2d182aefae80984a08c231ab57a3504063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined mouse-tracking behavior in foreground effect layers.
  * Updated grid animation rendering structure.
  * Modified background animation to use transform-based techniques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->