### PR TITLE
fix(audio): reuse singleton AudioContext in SoundManager

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -8,7 +8,7 @@
 
 ## 阶段 0：正确性修复（立即做，无依赖）
 
-- [ ] **#1 SoundManager AudioContext 泄漏** —— 改为模块级单例 + 复用 `ctx`，蜂鸣结束 `osc.onended` 中释放节点；补充 `ctx.state === "suspended"` 时的 `resume()` 处理（autoplay 策略）。*S*
+- [x] **#1 SoundManager AudioContext 泄漏** —— 改为模块级单例 + 复用 `ctx`，蜂鸣结束 `osc.onended` 中释放节点；补充 `ctx.state === "suspended"` 时的 `resume()` 处理（autoplay 策略）。*S*
 
 ## 阶段 1：质量门禁（为一切后续改动兜底）
 

--- a/src/components/SoundManager.tsx
+++ b/src/components/SoundManager.tsx
@@ -6,68 +6,109 @@ import {
     SOUND_TICK_DURATION,
 } from "../constants";
 
-// 简单的振荡器蜂鸣声
-const playBeep = (
-    vol: number = 0.5,
-    type: "start" | "end" | "tick" = "tick",
-) => {
-    const AudioContext =
+type BeepType = "start" | "end" | "tick";
+
+/** 模块级单例：避免每次蜂鸣 new AudioContext() 耗尽浏览器配额 */
+let sharedAudioContext: AudioContext | null = null;
+
+const getAudioContext = (): AudioContext | null => {
+    const AudioContextCtor =
         window.AudioContext ||
         (window as Window & { webkitAudioContext?: typeof window.AudioContext })
             .webkitAudioContext;
-    if (!AudioContext) return;
+    if (!AudioContextCtor) return null;
 
-    const ctx = new AudioContext();
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
+    if (!sharedAudioContext || sharedAudioContext.state === "closed") {
+        sharedAudioContext = new AudioContextCtor();
+    }
+    return sharedAudioContext;
+};
 
-    osc.connect(gain);
-    gain.connect(ctx.destination);
+const disconnectNodes = (...nodes: AudioNode[]) => {
+    for (const node of nodes) {
+        try {
+            node.disconnect();
+        } catch {
+            // 节点可能已断开
+        }
+    }
+};
 
-    const now = ctx.currentTime;
+// 简单的振荡器蜂鸣声（复用单例 AudioContext）
+const playBeep = async (vol: number = 0.5, type: BeepType = "tick") => {
+    const ctx = getAudioContext();
+    if (!ctx) return;
 
-    if (type === "start") {
-        osc.frequency.setValueAtTime(600, now);
-        osc.frequency.exponentialRampToValueAtTime(
-            1200,
-            now + SOUND_START_RAMP,
-        );
-        gain.gain.setValueAtTime(vol, now);
-        gain.gain.exponentialRampToValueAtTime(
-            0.01,
-            now + SOUND_START_DURATION,
-        );
-        osc.start(now);
-        osc.stop(now + SOUND_START_DURATION);
-    } else if (type === "end") {
-        osc.frequency.setValueAtTime(800, now);
-        osc.frequency.exponentialRampToValueAtTime(
-            300,
-            now + SOUND_END_DURATION,
-        );
-        // 双重蜂鸣
-        gain.gain.setValueAtTime(vol, now);
-        gain.gain.exponentialRampToValueAtTime(0.01, now + SOUND_END_DURATION);
-        osc.start(now);
-        osc.stop(now + SOUND_END_DURATION);
-    } else {
-        // 滴答声
-        osc.frequency.setValueAtTime(1000, now);
-        gain.gain.setValueAtTime(vol * 0.2, now);
-        gain.gain.exponentialRampToValueAtTime(
-            0.001,
-            now + SOUND_TICK_DURATION,
-        );
-        osc.start(now);
-        osc.stop(now + SOUND_TICK_DURATION);
+    // autoplay 策略下可能处于 suspended，需在用户手势后的调用链中 resume
+    if (ctx.state === "suspended") {
+        try {
+            await ctx.resume();
+        } catch {
+            return;
+        }
+    }
+
+    try {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+
+        osc.onended = () => {
+            disconnectNodes(osc, gain);
+        };
+
+        const now = ctx.currentTime;
+
+        if (type === "start") {
+            osc.frequency.setValueAtTime(600, now);
+            osc.frequency.exponentialRampToValueAtTime(
+                1200,
+                now + SOUND_START_RAMP,
+            );
+            gain.gain.setValueAtTime(vol, now);
+            gain.gain.exponentialRampToValueAtTime(
+                0.01,
+                now + SOUND_START_DURATION,
+            );
+            osc.start(now);
+            osc.stop(now + SOUND_START_DURATION);
+        } else if (type === "end") {
+            osc.frequency.setValueAtTime(800, now);
+            osc.frequency.exponentialRampToValueAtTime(
+                300,
+                now + SOUND_END_DURATION,
+            );
+            // 双重蜂鸣
+            gain.gain.setValueAtTime(vol, now);
+            gain.gain.exponentialRampToValueAtTime(
+                0.01,
+                now + SOUND_END_DURATION,
+            );
+            osc.start(now);
+            osc.stop(now + SOUND_END_DURATION);
+        } else {
+            // 滴答声
+            osc.frequency.setValueAtTime(1000, now);
+            gain.gain.setValueAtTime(vol * 0.2, now);
+            gain.gain.exponentialRampToValueAtTime(
+                0.001,
+                now + SOUND_TICK_DURATION,
+            );
+            osc.start(now);
+            osc.stop(now + SOUND_TICK_DURATION);
+        }
+    } catch {
+        // 节点创建/调度失败时静默跳过，避免 fire-and-forget 产生未处理 rejection
     }
 };
 
 export const useSound = (enabled: boolean, volume: number) => {
     return useCallback(
-        (type: "start" | "end" | "tick") => {
+        (type: BeepType) => {
             if (enabled) {
-                playBeep(volume, type);
+                void playBeep(volume, type);
             }
         },
         [enabled, volume],

--- a/src/components/SoundManager.tsx
+++ b/src/components/SoundManager.tsx
@@ -8,6 +8,9 @@ import {
 
 type BeepType = "start" | "end" | "tick";
 
+/** autoplay 拦截下 resume() 可能永不 settle，超时后跳过本次蜂鸣 */
+const AUDIO_CONTEXT_RESUME_TIMEOUT_MS = 200;
+
 /** 模块级单例：避免每次蜂鸣 new AudioContext() 耗尽浏览器配额 */
 let sharedAudioContext: AudioContext | null = null;
 
@@ -19,7 +22,11 @@ const getAudioContext = (): AudioContext | null => {
     if (!AudioContextCtor) return null;
 
     if (!sharedAudioContext || sharedAudioContext.state === "closed") {
-        sharedAudioContext = new AudioContextCtor();
+        try {
+            sharedAudioContext = new AudioContextCtor();
+        } catch {
+            return null;
+        }
     }
     return sharedAudioContext;
 };
@@ -34,23 +41,40 @@ const disconnectNodes = (...nodes: AudioNode[]) => {
     }
 };
 
+const resumeAudioContext = async (ctx: AudioContext): Promise<boolean> => {
+    if (ctx.state !== "suspended") return true;
+    try {
+        await Promise.race([
+            ctx.resume(),
+            new Promise<never>((_, reject) => {
+                window.setTimeout(
+                    () => reject(new Error("AudioContext resume timeout")),
+                    AUDIO_CONTEXT_RESUME_TIMEOUT_MS,
+                );
+            }),
+        ]);
+        return ctx.state === "running";
+    } catch {
+        return false;
+    }
+};
+
 // 简单的振荡器蜂鸣声（复用单例 AudioContext）
 const playBeep = async (vol: number = 0.5, type: BeepType = "tick") => {
+    // exponentialRamp 要求正数起点；非正音量无法发出有效蜂鸣
+    if (!(vol > 0)) return;
+
     const ctx = getAudioContext();
     if (!ctx) return;
 
-    // autoplay 策略下可能处于 suspended，需在用户手势后的调用链中 resume
-    if (ctx.state === "suspended") {
-        try {
-            await ctx.resume();
-        } catch {
-            return;
-        }
-    }
+    // autoplay 策略下可能处于 suspended；超时则跳过，避免永久挂起
+    if (!(await resumeAudioContext(ctx))) return;
 
+    const createdNodes: AudioNode[] = [];
     try {
         const osc = ctx.createOscillator();
         const gain = ctx.createGain();
+        createdNodes.push(osc, gain);
 
         osc.connect(gain);
         gain.connect(ctx.destination);
@@ -100,7 +124,8 @@ const playBeep = async (vol: number = 0.5, type: BeepType = "tick") => {
             osc.stop(now + SOUND_TICK_DURATION);
         }
     } catch {
-        // 节点创建/调度失败时静默跳过，避免 fire-and-forget 产生未处理 rejection
+        // 调度失败时 onended 不会触发，主动断开已连接节点
+        disconnectNodes(...createdNodes);
     }
 };
 


### PR DESCRIPTION
## Summary
- Fix SoundManager AudioContext leak by reusing a module-level singleton instead of creating a new context per beep
- Resume suspended contexts for autoplay policy; disconnect oscillator/gain nodes on `onended`
- Mark OPTIMIZATION_TODO #1 as done

## Test plan
- [ ] Enable sound and trigger start / end / tick beeps — audio still plays
- [ ] Rapidly trigger multiple beeps — no AudioContext errors in console
- [ ] `pnpm lint && pnpm check` pass locally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `AudioContext` leak in `SoundManager` by reusing a module-level singleton, preventing quota exhaustion and keeping beeps reliable under rapid triggers. Adds guardrails so autoplay resume and scheduling don’t hang or leak.

- **Bug Fixes**
  - Reuse a module-level `AudioContext` (recreate if closed) with safe construction.
  - Resume when suspended, racing with a short timeout; skip playback on failure or non‑positive volume.
  - Disconnect oscillator and gain in `onended` and when scheduling throws to release resources.
  - Marked the `SoundManager` leak item as done in `docs/OPTIMIZATION_TODO.md`.

<sup>Written for commit ac6366c069afc98ba476b73897139b2cc13ee8bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

