### PR TITLE
test: add Vitest coverage for core pure logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
+<<<<<<< HEAD
           # pnpm 11 requires Node >=22.13; pin a current 22.x patch for CI reproducibility
+=======
+<<<<<<< HEAD
+          # pnpm 11 needs >=22.13; jsdom 30 (tests) needs >=22.22.2
+=======
+>>>>>>> a41e0c4 (test: add Vitest coverage for core pure logic)
+>>>>>>> 430c6b4 (test: add Vitest coverage for core pure logic)
           node-version: 22.22.2
           cache: pnpm
 
@@ -40,6 +47,9 @@ jobs:
 
       - name: Ensure check left working tree clean
         run: test -z "$(git status --porcelain)"
+
+      - name: Test
+        run: pnpm test
 
       - name: Build
         run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ dist-ssr
 *.sw?
 .env
 .claude
+
+# Local agent / indexer scratch (do not commit)
+.codegraph/
+.superpowers/

--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -19,7 +19,7 @@
   - [x] `musicApiAdapters.parseResponse`（字段回退、空数组抛错）
   - [x] `SettingsPanel.parseDurationInput`、设置反序列化校验（与 #10 联动）
   - [x] `Pomodoro` 状态机（完成流转纯函数 `advancePomodoroState`；重置/跳过组件级留待后续）
-  - 将 `pnpm test` 挂入 CI。*L*
+  - [x] 将 `pnpm test` 挂入 CI。*L*
 
 ## 阶段 2：低成本清理（快速胜利，不改行为）
 

--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -13,12 +13,12 @@
 ## 阶段 1：质量门禁（为一切后续改动兜底）
 
 - [x] **#3 建立 CI** —— `.github/workflows/ci.yml`：pnpm install → lint → check → build。*S*
-- [ ] **#2 测试基建** —— 引入 Vitest（+ @testing-library/react、jsdom/happy-dom），先覆盖纯逻辑：
-  - [ ] `useShuffle`（洗牌不重不漏、循环重洗、首尾相接规避）
-  - [ ] `asyncPool`（并发上限、结果保序、异常传播）
-  - [ ] `musicApiAdapters.parseResponse`（字段回退、空数组抛错）
-  - [ ] `SettingsPanel.parseDurationInput`、设置反序列化校验（与 #10 联动）
-  - [ ] `Pomodoro` 状态机（完成流转、重置、跳过语义）——组件级，最后补
+- [x] **#2 测试基建** —— 引入 Vitest（+ @testing-library/react、jsdom/happy-dom），先覆盖纯逻辑：
+  - [x] `useShuffle`（洗牌不重不漏、循环重洗、首尾相接规避）
+  - [x] `asyncPool`（并发上限、结果保序、异常传播）
+  - [x] `musicApiAdapters.parseResponse`（字段回退、空数组抛错）
+  - [x] `SettingsPanel.parseDurationInput`、设置反序列化校验（与 #10 联动）
+  - [x] `Pomodoro` 状态机（完成流转纯函数 `advancePomodoroState`；重置/跳过组件级留待后续）
   - 将 `pnpm test` 挂入 CI。*L*
 
 ## 阶段 2：低成本清理（快速胜利，不改行为）

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
         "lint": "eslint .",
         "format": "biome format --write .",
         "check": "biome check --write .",
+        "test": "vitest run",
+        "test:watch": "vitest",
         "preview": "vite preview"
     },
     "dependencies": {
@@ -27,6 +29,9 @@
         "@biomejs/biome": "^2.5.5",
         "@eslint/js": "^10.0.1",
         "@rolldown/plugin-babel": "^0.2.3",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/babel__core": "^7.20.5",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
@@ -37,9 +42,11 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
+        "jsdom": "^30.0.1",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0",
         "vite": "^8.1.5",
-        "vite-plugin-pwa": "^1.3.0"
+        "vite-plugin-pwa": "^1.3.0",
+        "vitest": "^4.1.10"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,15 @@ importers:
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: ^7.0.0
+        version: 7.0.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -78,6 +87,9 @@ importers:
       globals:
         specifier: ^17.7.0
         version: 17.7.0
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -90,14 +102,28 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.3.0
         version: 1.3.0(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.1)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(jsdom@30.0.1)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@apideck/better-ajv-errors@0.3.7':
     resolution: {integrity: sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==}
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@asamuzakjp/css-color@6.0.5':
+    resolution: {integrity: sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -717,6 +743,46 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
@@ -764,6 +830,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -981,6 +1056,9 @@ packages:
       rollup:
         optional: true
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
@@ -1078,6 +1156,31 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@7.0.0':
+    resolution: {integrity: sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -1087,6 +1190,9 @@ packages:
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1099,6 +1205,12 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -1210,6 +1322,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@xobotyi/scrollbar-width@1.9.5':
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
 
@@ -1229,6 +1370,21 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -1236,6 +1392,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1282,6 +1442,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
@@ -1311,6 +1474,10 @@ packages:
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1347,8 +1514,19 @@ packages:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
     engines: {node: '>=8.0.0'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1371,6 +1549,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1386,9 +1567,19 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1410,6 +1601,10 @@ packages:
     resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
@@ -1428,6 +1623,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1504,9 +1702,16 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1661,6 +1866,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
 
@@ -1684,6 +1893,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
@@ -1763,6 +1976,9 @@ packages:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1834,6 +2050,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2045,6 +2270,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
@@ -2058,9 +2287,16 @@ packages:
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   media-typer@2.0.0:
     resolution: {integrity: sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2134,6 +2370,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2148,6 +2387,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2180,6 +2422,10 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2191,6 +2437,9 @@ packages:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
       react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-universal-interface@0.6.2:
     resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
@@ -2207,6 +2456,10 @@ packages:
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2277,6 +2530,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2336,6 +2593,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2370,6 +2630,9 @@ packages:
   stack-generator@2.0.10:
     resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -2378,6 +2641,9 @@ packages:
 
   stacktrace-js@2.0.2:
     resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2407,6 +2673,10 @@ packages:
     resolution: {integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==}
     engines: {node: '>=10'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
@@ -2417,6 +2687,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
@@ -2442,9 +2715,27 @@ packages:
     resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
     engines: {node: '>=10'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
 
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
@@ -2452,6 +2743,14 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2511,6 +2810,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -2604,6 +2907,67 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2623,6 +2987,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   win-guid@0.2.1:
@@ -2687,6 +3056,13 @@ packages:
   workbox-window@7.4.1:
     resolution: {integrity: sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2705,11 +3081,28 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
   '@apideck/better-ajv-errors@0.3.7(ajv@8.20.0)':
     dependencies:
       ajv: 8.20.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+
+  '@asamuzakjp/css-color@6.0.5':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3492,6 +3885,34 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -3541,6 +3962,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3703,6 +4126,8 @@ snapshots:
     optionalDependencies:
       rollup: 2.80.0
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -3778,6 +4203,37 @@ snapshots:
       tailwindcss: 4.3.3
       vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -3791,6 +4247,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3812,6 +4270,13 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -3942,6 +4407,47 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0))
       babel-plugin-react-compiler: 1.0.0
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@xobotyi/scrollbar-width@1.9.5': {}
 
   acorn-jsx@5.3.2(acorn@8.17.0):
@@ -3964,6 +4470,16 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -3978,6 +4494,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
 
@@ -4023,6 +4541,10 @@ snapshots:
 
   baseline-browser-mapping@2.11.1: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
@@ -4060,6 +4582,8 @@ snapshots:
 
   caniuse-lite@1.0.30001806: {}
 
+  chai@6.2.2: {}
+
   commander@2.20.3: {}
 
   common-tags@1.8.2: {}
@@ -4093,7 +4617,21 @@ snapshots:
       mdn-data: 2.0.14
       source-map: 0.6.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -4117,6 +4655,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -4133,7 +4673,13 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4153,6 +4699,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -4225,6 +4773,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -4333,7 +4883,13 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4495,6 +5051,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   hyphenate-style-name@1.1.0: {}
 
   idb@7.1.1: {}
@@ -4508,6 +5070,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inline-style-prefixer@7.0.1:
     dependencies:
@@ -4594,6 +5158,8 @@ snapshots:
 
   is-obj@1.0.1: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -4658,6 +5224,32 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.5
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4806,6 +5398,8 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  lz-string@1.5.0: {}
+
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
@@ -4818,7 +5412,11 @@ snapshots:
 
   mdn-data@2.0.14: {}
 
+  mdn-data@2.27.1: {}
+
   media-typer@2.0.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4907,6 +5505,10 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -4917,6 +5519,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -4938,6 +5542,12 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   punycode@2.3.1: {}
 
   randombytes@2.1.0:
@@ -4948,6 +5558,8 @@ snapshots:
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-universal-interface@0.6.2(react@19.2.8)(tslib@2.8.1):
     dependencies:
@@ -4974,6 +5586,11 @@ snapshots:
       tslib: 2.8.1
 
   react@19.2.8: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5079,6 +5696,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   screenfull@5.2.0: {}
@@ -5149,6 +5770,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   smob@1.6.2: {}
@@ -5172,6 +5795,8 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   stacktrace-gps@3.1.2:
@@ -5184,6 +5809,8 @@ snapshots:
       error-stack-parser: 2.1.4
       stack-generator: 2.0.10
       stacktrace-gps: 3.1.2
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5238,6 +5865,10 @@ snapshots:
 
   strip-comments@2.0.1: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -5245,6 +5876,8 @@ snapshots:
   stylis@4.4.0: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@4.3.3: {}
 
@@ -5268,10 +5901,22 @@ snapshots:
 
   throttle-debounce@3.0.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
 
   toggle-selection@1.0.6: {}
 
@@ -5280,6 +5925,14 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -5352,6 +6005,8 @@ snapshots:
 
   undici-types@8.3.0: {}
 
+  undici@8.10.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -5405,6 +6060,58 @@ snapshots:
       jiti: 2.7.0
       terser: 5.49.0
 
+  vitest@4.1.10(@types/node@26.1.1)(jsdom@30.0.1)(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.5(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -5449,6 +6156,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   win-guid@0.2.1: {}
 
@@ -5573,6 +6285,10 @@ snapshots:
     dependencies:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { useSessionStats } from "./hooks/useSessionStats";
 import type { Settings } from "./types";
 import { Language, ThemePreset, TimerMode, View } from "./types";
 import { useTranslation } from "./utils/i18n";
+import { parseStoredSettings } from "./utils/settings";
 
 const DEFAULT_SETTINGS: Settings = {
     workDuration: 25,
@@ -43,36 +44,11 @@ const App: React.FC = () => {
     // 从localStorage加载设置
     const [settings, setSettings] = useState<Settings>(() => {
         const saved = localStorage.getItem(STORAGE_KEYS.SETTINGS);
-        if (saved) {
-            try {
-                const parsed = JSON.parse(saved);
-                if (
-                    parsed &&
-                    typeof parsed === "object" &&
-                    !Array.isArray(parsed)
-                ) {
-                    const loadedSettings = { ...DEFAULT_SETTINGS, ...parsed };
-                    // 检测通知权限被撤销时自动取消勾选
-                    if (
-                        loadedSettings.notificationsEnabled &&
-                        "Notification" in window &&
-                        Notification.permission === "denied"
-                    ) {
-                        loadedSettings.notificationsEnabled = false;
-                    }
-
-                    // Theme Migration: Handle legacy "LABORATORY" theme which was renamed to "AZURE"
-                    if (loadedSettings.theme === "LABORATORY") {
-                        loadedSettings.theme = ThemePreset.AZURE;
-                    }
-
-                    return loadedSettings;
-                }
-            } catch (e) {
-                console.error("Failed to load settings", e);
-            }
-        }
-        return DEFAULT_SETTINGS;
+        const notificationPermission =
+            "Notification" in window ? Notification.permission : null;
+        return parseStoredSettings(saved, DEFAULT_SETTINGS, {
+            notificationPermission,
+        });
     });
 
     // 临时音乐配置状态，用于在点击应用前存储更改

--- a/src/components/Pomodoro.tsx
+++ b/src/components/Pomodoro.tsx
@@ -9,6 +9,7 @@ import {
 import type { Settings } from "../types";
 import { TimerMode } from "../types";
 import { useTranslation } from "../utils/i18n";
+import { advancePomodoroState } from "../utils/pomodoroState";
 import { useSound } from "./SoundManager";
 import { Button, Panel } from "./ui";
 
@@ -159,28 +160,28 @@ const Pomodoro: React.FC<PomodoroProps> = ({
     const handleComplete = () => {
         playSound("end");
 
+        const { nextMode, nextSessionCount } = advancePomodoroState(
+            mode,
+            sessionCount,
+            LONG_BREAK_INTERVAL,
+        );
+
         if (mode === TimerMode.WORK) {
             sendNotification(
                 t("NOTIFICATION_WORK_COMPLETE_TITLE"),
                 t("NOTIFICATION_WORK_COMPLETE_BODY"),
             );
-            const newCount = sessionCount + 1;
-            onSessionsUpdate(newCount);
-
+            onSessionsUpdate(nextSessionCount);
             shouldAutoStartRef.current = settingsRef.current.autoStartBreaks;
-            if (newCount % LONG_BREAK_INTERVAL === 0) {
-                setMode(TimerMode.LONG_BREAK);
-            } else {
-                setMode(TimerMode.SHORT_BREAK);
-            }
         } else {
             sendNotification(
                 t("NOTIFICATION_BREAK_COMPLETE_TITLE"),
                 t("NOTIFICATION_BREAK_COMPLETE_BODY"),
             );
             shouldAutoStartRef.current = settingsRef.current.autoStartWork;
-            setMode(TimerMode.WORK);
         }
+
+        setMode(nextMode);
     };
 
     const resetTimer = () => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Settings } from "../types";
 import { Language, ThemePreset } from "../types";
 import { useTranslation } from "../utils/i18n";
+import { parseDurationInput } from "../utils/settings";
 import { Checkbox } from "./Checkbox";
 import { CustomSelect } from "./CustomSelect";
 import { Button, Input, Panel } from "./ui";
@@ -30,13 +31,6 @@ const getMusicPlatformOptions = (t: ReturnType<typeof useTranslation>) => [
 const getMusicTypeOptions = (t: ReturnType<typeof useTranslation>) => [
     { value: "playlist", label: t("TYPE_PLAYLIST") },
 ];
-
-const parseDurationInput = (value: string, previous: number): number => {
-    if (value.trim() === "") return previous;
-    const next = Number(value);
-    if (!Number.isFinite(next)) return previous;
-    return Math.max(1, Math.floor(next));
-};
 
 const SettingsPanel: React.FC<SettingsPanelProps> = ({
     settings,

--- a/src/hooks/useShuffle.test.ts
+++ b/src/hooks/useShuffle.test.ts
@@ -67,6 +67,16 @@ describe("useShuffle", () => {
     });
 
     it("avoids repeating the last track immediately when reshuffling", async () => {
+        let call = 0;
+        vi.spyOn(Math, "random").mockImplementation(() => {
+            call += 1;
+            // 初始洗牌：保持恒等 [0,1,2]
+            // 重洗：使首项等于上一曲末项 2，从而命中首尾相接 swap
+            if (call <= 2) return 0.999;
+            if (call === 3) return 0; // i=2 → j=0 → [2,1,0]
+            return 0.999; // i=1 → j=1 → 保持 [2,1,0]，再被 swap 成 [1,2,0]
+        });
+
         const { result, rerender } = renderHook(
             ({ currentIndex }) => useShuffle(3, PlayMode.RANDOM, currentIndex),
             { initialProps: { currentIndex: 0 } },
@@ -74,7 +84,6 @@ describe("useShuffle", () => {
 
         await flushMicrotasks();
 
-        // Advance to the last index in the identity order [0,1,2]
         let current = 0;
         for (let i = 0; i < 2; i++) {
             let next = -1;
@@ -86,14 +95,12 @@ describe("useShuffle", () => {
         }
         expect(current).toBe(2);
 
-        // Next call reshuffles; head-tail guard must not start with 2
         let reshuffledFirst = -1;
         act(() => {
             reshuffledFirst = result.current.getNextRandomIndex();
         });
 
-        expect(reshuffledFirst).not.toBe(2);
-        expect(reshuffledFirst).toBeGreaterThanOrEqual(0);
-        expect(reshuffledFirst).toBeLessThan(3);
+        // 若无 swap，首项会是 2；防护生效后应为 1
+        expect(reshuffledFirst).toBe(1);
     });
 });

--- a/src/hooks/useShuffle.test.ts
+++ b/src/hooks/useShuffle.test.ts
@@ -1,74 +1,99 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PlayMode } from "../types";
 import { useShuffle } from "./useShuffle";
 
+/** Flush queueMicrotask used by useShuffle's init effect */
+const flushMicrotasks = async () => {
+    await act(async () => {
+        await Promise.resolve();
+    });
+};
+
 describe("useShuffle", () => {
     beforeEach(() => {
-        vi.spyOn(Math, "random").mockReturnValue(0);
+        // random ≈ 1 → Fisher-Yates 不做交换，洗牌结果保持 [0,1,2,...]
+        vi.spyOn(Math, "random").mockReturnValue(0.999);
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
-    it("shuffles without duplicates or missing indices", async () => {
-        const { result } = renderHook(() => useShuffle(5, PlayMode.RANDOM, 0));
-
-        await waitFor(() => {
-            expect(result.current.shuffledIndices).toHaveLength(5);
-        });
-
-        const indices = result.current.shuffledIndices;
-        expect(new Set(indices).size).toBe(5);
-        expect([...indices].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
-    });
-
-    it("cycles through all indices before reshuffling", async () => {
+    it("yields each index exactly once before reshuffling", async () => {
         const { result, rerender } = renderHook(
-            ({ currentIndex }) => useShuffle(3, PlayMode.RANDOM, currentIndex),
+            ({ currentIndex }) => useShuffle(5, PlayMode.RANDOM, currentIndex),
             { initialProps: { currentIndex: 0 } },
         );
 
-        await waitFor(() => {
-            expect(result.current.shuffledIndices).toHaveLength(3);
-        });
+        await flushMicrotasks();
 
-        const order = [...result.current.shuffledIndices];
-        rerender({ currentIndex: order[0] });
-
-        const seen: number[] = [];
-        for (let i = 0; i < 2; i++) {
+        const seen = new Set<number>([0]);
+        let current = 0;
+        for (let i = 0; i < 4; i++) {
             let next = -1;
             act(() => {
                 next = result.current.getNextRandomIndex();
             });
-            seen.push(next);
-            rerender({ currentIndex: next });
+            expect(next).toBe(current + 1);
+            expect(seen.has(next)).toBe(false);
+            seen.add(next);
+            current = next;
+            rerender({ currentIndex: current });
         }
 
-        expect(seen).toEqual([order[1], order[2]]);
+        expect(seen.size).toBe(5);
+        expect([...seen].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
     });
 
-    it("avoids head-tail collision when reshuffling after full cycle", async () => {
+    it("peekNextRandomIndex matches the next getNextRandomIndex value", async () => {
         const { result, rerender } = renderHook(
-            ({ currentIndex }) => useShuffle(3, PlayMode.RANDOM, currentIndex),
+            ({ currentIndex }) => useShuffle(4, PlayMode.RANDOM, currentIndex),
             { initialProps: { currentIndex: 0 } },
         );
 
-        await waitFor(() => {
-            expect(result.current.shuffledIndices).toHaveLength(3);
-        });
+        await flushMicrotasks();
 
-        const initial = [...result.current.shuffledIndices];
-        rerender({ currentIndex: initial[initial.length - 1] });
+        expect(result.current.peekNextRandomIndex()).toBe(1);
 
         let next = -1;
         act(() => {
             next = result.current.getNextRandomIndex();
         });
+        expect(next).toBe(1);
 
-        expect(next).not.toBe(initial[initial.length - 1]);
-        expect(result.current.shuffledIndices[0]).toBe(next);
+        rerender({ currentIndex: next });
+        expect(result.current.peekNextRandomIndex()).toBe(2);
+    });
+
+    it("avoids repeating the last track immediately when reshuffling", async () => {
+        const { result, rerender } = renderHook(
+            ({ currentIndex }) => useShuffle(3, PlayMode.RANDOM, currentIndex),
+            { initialProps: { currentIndex: 0 } },
+        );
+
+        await flushMicrotasks();
+
+        // Advance to the last index in the identity order [0,1,2]
+        let current = 0;
+        for (let i = 0; i < 2; i++) {
+            let next = -1;
+            act(() => {
+                next = result.current.getNextRandomIndex();
+            });
+            current = next;
+            rerender({ currentIndex: current });
+        }
+        expect(current).toBe(2);
+
+        // Next call reshuffles; head-tail guard must not start with 2
+        let reshuffledFirst = -1;
+        act(() => {
+            reshuffledFirst = result.current.getNextRandomIndex();
+        });
+
+        expect(reshuffledFirst).not.toBe(2);
+        expect(reshuffledFirst).toBeGreaterThanOrEqual(0);
+        expect(reshuffledFirst).toBeLessThan(3);
     });
 });

--- a/src/hooks/useShuffle.test.ts
+++ b/src/hooks/useShuffle.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlayMode } from "../types";
+import { useShuffle } from "./useShuffle";
+
+describe("useShuffle", () => {
+    beforeEach(() => {
+        vi.spyOn(Math, "random").mockReturnValue(0);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("shuffles without duplicates or missing indices", async () => {
+        const { result } = renderHook(() => useShuffle(5, PlayMode.RANDOM, 0));
+
+        await waitFor(() => {
+            expect(result.current.shuffledIndices).toHaveLength(5);
+        });
+
+        const indices = result.current.shuffledIndices;
+        expect(new Set(indices).size).toBe(5);
+        expect([...indices].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it("cycles through all indices before reshuffling", async () => {
+        const { result, rerender } = renderHook(
+            ({ currentIndex }) => useShuffle(3, PlayMode.RANDOM, currentIndex),
+            { initialProps: { currentIndex: 0 } },
+        );
+
+        await waitFor(() => {
+            expect(result.current.shuffledIndices).toHaveLength(3);
+        });
+
+        const order = [...result.current.shuffledIndices];
+        rerender({ currentIndex: order[0] });
+
+        const seen: number[] = [];
+        for (let i = 0; i < 2; i++) {
+            let next = -1;
+            act(() => {
+                next = result.current.getNextRandomIndex();
+            });
+            seen.push(next);
+            rerender({ currentIndex: next });
+        }
+
+        expect(seen).toEqual([order[1], order[2]]);
+    });
+
+    it("avoids head-tail collision when reshuffling after full cycle", async () => {
+        const { result, rerender } = renderHook(
+            ({ currentIndex }) => useShuffle(3, PlayMode.RANDOM, currentIndex),
+            { initialProps: { currentIndex: 0 } },
+        );
+
+        await waitFor(() => {
+            expect(result.current.shuffledIndices).toHaveLength(3);
+        });
+
+        const initial = [...result.current.shuffledIndices];
+        rerender({ currentIndex: initial[initial.length - 1] });
+
+        let next = -1;
+        act(() => {
+            next = result.current.getNextRandomIndex();
+        });
+
+        expect(next).not.toBe(initial[initial.length - 1]);
+        expect(result.current.shuffledIndices[0]).toBe(next);
+    });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/src/utils/asyncPool.test.ts
+++ b/src/utils/asyncPool.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { asyncPool } from "./asyncPool";
+
+describe("asyncPool", () => {
+    it("respects concurrency limit", async () => {
+        let running = 0;
+        let maxRunning = 0;
+
+        await asyncPool(2, [1, 2, 3, 4, 5], async () => {
+            running += 1;
+            maxRunning = Math.max(maxRunning, running);
+            await new Promise((r) => setTimeout(r, 20));
+            running -= 1;
+            return true;
+        });
+
+        expect(maxRunning).toBeLessThanOrEqual(2);
+    });
+
+    it("preserves result order matching input order", async () => {
+        const results = await asyncPool(2, [1, 2, 3], async (n) => {
+            await new Promise((r) => setTimeout(r, (4 - n) * 10));
+            return n * 10;
+        });
+        expect(results).toEqual([10, 20, 30]);
+    });
+
+    it("propagates task errors", async () => {
+        await expect(
+            asyncPool(2, [1, 2, 3], async (n) => {
+                if (n === 2) throw new Error("boom");
+                return n;
+            }),
+        ).rejects.toThrow("boom");
+    });
+
+    it("runs all in parallel when limit <= 0", async () => {
+        let running = 0;
+        let maxRunning = 0;
+
+        await asyncPool(0, [1, 2, 3], async () => {
+            running += 1;
+            maxRunning = Math.max(maxRunning, running);
+            await new Promise((r) => setTimeout(r, 15));
+            running -= 1;
+        });
+
+        expect(maxRunning).toBe(3);
+    });
+});

--- a/src/utils/musicApiAdapters.test.ts
+++ b/src/utils/musicApiAdapters.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { metingAdapter } from "./musicApiAdapters";
+
+describe("metingAdapter.parseResponse", () => {
+    it("maps primary fields", () => {
+        const tracks = metingAdapter.parseResponse([
+            {
+                id: "1",
+                name: "Song A",
+                artist: "Artist A",
+                url: "https://example.com/a.mp3",
+                pic: "https://example.com/a.jpg",
+                lrc: "[00:00.00]hi",
+                theme: "#fff",
+            },
+        ]);
+
+        expect(tracks).toEqual([
+            {
+                id: "1",
+                name: "Song A",
+                artist: "Artist A",
+                url: "https://example.com/a.mp3",
+                cover: "https://example.com/a.jpg",
+                lrc: "[00:00.00]hi",
+                theme: "#fff",
+            },
+        ]);
+    });
+
+    it("falls back to alternate field names and defaults", () => {
+        const tracks = metingAdapter.parseResponse([
+            {
+                song_id: "9",
+                title: "Alt",
+                author: "Writer",
+                cover: "https://example.com/c.jpg",
+            },
+        ]);
+
+        expect(tracks[0]).toMatchObject({
+            id: "9",
+            name: "Alt",
+            artist: "Writer",
+            url: "",
+            cover: "https://example.com/c.jpg",
+            lrc: "",
+        });
+    });
+
+    it("throws on empty array", () => {
+        expect(() => metingAdapter.parseResponse([])).toThrow("Empty playlist");
+    });
+
+    it("throws on non-array", () => {
+        expect(() => metingAdapter.parseResponse({ ok: true })).toThrow(
+            "Empty playlist",
+        );
+    });
+});

--- a/src/utils/pomodoroState.test.ts
+++ b/src/utils/pomodoroState.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { TimerMode } from "../types";
+import { advancePomodoroState } from "./pomodoroState";
+
+describe("advancePomodoroState", () => {
+    it("moves work completion to short break and increments session", () => {
+        expect(advancePomodoroState(TimerMode.WORK, 0)).toEqual({
+            nextMode: TimerMode.SHORT_BREAK,
+            nextSessionCount: 1,
+        });
+        expect(advancePomodoroState(TimerMode.WORK, 2)).toEqual({
+            nextMode: TimerMode.SHORT_BREAK,
+            nextSessionCount: 3,
+        });
+    });
+
+    it("enters long break every 4th completed work session", () => {
+        expect(advancePomodoroState(TimerMode.WORK, 3)).toEqual({
+            nextMode: TimerMode.LONG_BREAK,
+            nextSessionCount: 4,
+        });
+        expect(advancePomodoroState(TimerMode.WORK, 7)).toEqual({
+            nextMode: TimerMode.LONG_BREAK,
+            nextSessionCount: 8,
+        });
+    });
+
+    it("returns to work after short or long break without changing session", () => {
+        expect(advancePomodoroState(TimerMode.SHORT_BREAK, 2)).toEqual({
+            nextMode: TimerMode.WORK,
+            nextSessionCount: 2,
+        });
+        expect(advancePomodoroState(TimerMode.LONG_BREAK, 4)).toEqual({
+            nextMode: TimerMode.WORK,
+            nextSessionCount: 4,
+        });
+    });
+});

--- a/src/utils/pomodoroState.ts
+++ b/src/utils/pomodoroState.ts
@@ -1,0 +1,29 @@
+import { LONG_BREAK_INTERVAL } from "../constants";
+import { TimerMode } from "../types";
+
+export type PomodoroAdvanceResult = {
+    nextMode: TimerMode;
+    nextSessionCount: number;
+};
+
+/**
+ * 番茄钟阶段完成时的模式/会话数流转（不含音效、通知、自动开始副作用）。
+ * 工作完成：session+1，每 longBreakInterval 次进入长休息，否则短休息。
+ * 休息完成：回到工作，会话数不变。
+ */
+export const advancePomodoroState = (
+    mode: TimerMode,
+    sessionCount: number,
+    longBreakInterval: number = LONG_BREAK_INTERVAL,
+): PomodoroAdvanceResult => {
+    if (mode === TimerMode.WORK) {
+        const nextSessionCount = sessionCount + 1;
+        const nextMode =
+            nextSessionCount % longBreakInterval === 0
+                ? TimerMode.LONG_BREAK
+                : TimerMode.SHORT_BREAK;
+        return { nextMode, nextSessionCount };
+    }
+
+    return { nextMode: TimerMode.WORK, nextSessionCount: sessionCount };
+};

--- a/src/utils/settings.test.ts
+++ b/src/utils/settings.test.ts
@@ -71,4 +71,28 @@ describe("parseStoredSettings", () => {
         );
         expect(result.theme).toBe(ThemePreset.AZURE);
     });
+
+    it("falls back dirty field types to defaults without crashing", () => {
+        const result = parseStoredSettings(
+            JSON.stringify({
+                workDuration: "abc",
+                soundVolume: 9,
+                theme: "NOT_A_THEME",
+                language: 123,
+                musicConfig: { server: 1, type: "playlist", id: null },
+                autoStartBreaks: "yes",
+            }),
+            defaults,
+        );
+        expect(result.workDuration).toBe(defaults.workDuration);
+        expect(result.soundVolume).toBe(1);
+        expect(result.theme).toBe(defaults.theme);
+        expect(result.language).toBe(defaults.language);
+        expect(result.musicConfig).toEqual({
+            server: defaults.musicConfig.server,
+            type: "playlist",
+            id: defaults.musicConfig.id,
+        });
+        expect(result.autoStartBreaks).toBe(defaults.autoStartBreaks);
+    });
 });

--- a/src/utils/settings.test.ts
+++ b/src/utils/settings.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { defaultMusicConfig } from "../config/musicConfig";
+import { Language, type Settings, ThemePreset } from "../types";
+import { parseDurationInput, parseStoredSettings } from "./settings";
+
+const defaults: Settings = {
+    workDuration: 25,
+    shortBreakDuration: 5,
+    longBreakDuration: 15,
+    autoStartBreaks: true,
+    autoStartWork: true,
+    soundEnabled: true,
+    soundVolume: 0.5,
+    notificationsEnabled: false,
+    language: Language.CN,
+    theme: ThemePreset.INDUSTRIAL,
+    musicConfig: defaultMusicConfig,
+};
+
+describe("parseDurationInput", () => {
+    it("returns previous for blank input", () => {
+        expect(parseDurationInput("   ", 25)).toBe(25);
+    });
+
+    it("returns previous for non-finite numbers", () => {
+        expect(parseDurationInput("abc", 10)).toBe(10);
+        expect(parseDurationInput("Infinity", 10)).toBe(10);
+    });
+
+    it("floors and clamps to at least 1", () => {
+        expect(parseDurationInput("3.9", 25)).toBe(3);
+        expect(parseDurationInput("0", 25)).toBe(1);
+        expect(parseDurationInput("-2", 25)).toBe(1);
+    });
+});
+
+describe("parseStoredSettings", () => {
+    it("returns defaults when saved is null", () => {
+        expect(parseStoredSettings(null, defaults)).toEqual(defaults);
+    });
+
+    it("shallow-merges object payloads", () => {
+        const result = parseStoredSettings(
+            JSON.stringify({ workDuration: 30, soundEnabled: false }),
+            defaults,
+        );
+        expect(result.workDuration).toBe(30);
+        expect(result.soundEnabled).toBe(false);
+        expect(result.shortBreakDuration).toBe(5);
+    });
+
+    it("falls back on invalid JSON or non-object", () => {
+        expect(parseStoredSettings("{", defaults)).toEqual(defaults);
+        expect(parseStoredSettings("[]", defaults)).toEqual(defaults);
+        expect(parseStoredSettings('"x"', defaults)).toEqual(defaults);
+    });
+
+    it("disables notifications when permission is denied", () => {
+        const result = parseStoredSettings(
+            JSON.stringify({ notificationsEnabled: true }),
+            defaults,
+            { notificationPermission: "denied" },
+        );
+        expect(result.notificationsEnabled).toBe(false);
+    });
+
+    it("migrates LABORATORY theme to AZURE", () => {
+        const result = parseStoredSettings(
+            JSON.stringify({ theme: "LABORATORY" }),
+            defaults,
+        );
+        expect(result.theme).toBe(ThemePreset.AZURE);
+    });
+});

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,0 +1,55 @@
+import type { Settings } from "../types";
+import { ThemePreset } from "../types";
+
+/** 解析设置面板时长输入：空/非有限数回退 previous，否则 floor 且 ≥1 */
+export const parseDurationInput = (value: string, previous: number): number => {
+    if (value.trim() === "") return previous;
+    const next = Number(value);
+    if (!Number.isFinite(next)) return previous;
+    return Math.max(1, Math.floor(next));
+};
+
+export type ParseStoredSettingsOptions = {
+    /** 传入 Notification.permission；无 Notification API 时传 null/undefined */
+    notificationPermission?: NotificationPermission | null;
+};
+
+/**
+ * 从 localStorage 原始字符串解析设置（浅合并默认值）。
+ * 脏 JSON / 非对象回退 defaults；LABORATORY → AZURE；通知被拒时关闭开关。
+ */
+export const parseStoredSettings = (
+    saved: string | null,
+    defaults: Settings,
+    options: ParseStoredSettingsOptions = {},
+): Settings => {
+    if (!saved) return { ...defaults };
+
+    try {
+        const parsed: unknown = JSON.parse(saved);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return { ...defaults };
+        }
+
+        const loadedSettings: Settings = {
+            ...defaults,
+            ...(parsed as Partial<Settings>),
+        };
+
+        if (
+            loadedSettings.notificationsEnabled &&
+            options.notificationPermission === "denied"
+        ) {
+            loadedSettings.notificationsEnabled = false;
+        }
+
+        // Theme Migration: legacy LABORATORY → AZURE
+        if ((loadedSettings.theme as string) === "LABORATORY") {
+            loadedSettings.theme = ThemePreset.AZURE;
+        }
+
+        return loadedSettings;
+    } catch {
+        return { ...defaults };
+    }
+};

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,5 +1,5 @@
 import type { Settings } from "../types";
-import { ThemePreset } from "../types";
+import { Language, ThemePreset } from "../types";
 
 /** 解析设置面板时长输入：空/非有限数回退 previous，否则 floor 且 ≥1 */
 export const parseDurationInput = (value: string, previous: number): number => {
@@ -14,8 +14,54 @@ export type ParseStoredSettingsOptions = {
     notificationPermission?: NotificationPermission | null;
 };
 
+const THEME_VALUES = new Set<string>(Object.values(ThemePreset));
+const LANGUAGE_VALUES = new Set<string>(Object.values(Language));
+
+const asPositiveIntMinutes = (value: unknown, fallback: number): number => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+    return Math.max(1, Math.floor(value));
+};
+
+const asBoolean = (value: unknown, fallback: boolean): boolean =>
+    typeof value === "boolean" ? value : fallback;
+
+const asSoundVolume = (value: unknown, fallback: number): number => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+    return Math.min(1, Math.max(0, value));
+};
+
+const asTheme = (value: unknown, fallback: ThemePreset): ThemePreset => {
+    if (value === "LABORATORY") return ThemePreset.AZURE;
+    if (typeof value === "string" && THEME_VALUES.has(value)) {
+        return value as ThemePreset;
+    }
+    return fallback;
+};
+
+const asLanguage = (value: unknown, fallback: Language): Language => {
+    if (typeof value === "string" && LANGUAGE_VALUES.has(value)) {
+        return value as Language;
+    }
+    return fallback;
+};
+
+const asMusicConfig = (
+    value: unknown,
+    fallback: Settings["musicConfig"],
+): Settings["musicConfig"] => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return { ...fallback };
+    }
+    const raw = value as Record<string, unknown>;
+    return {
+        server: typeof raw.server === "string" ? raw.server : fallback.server,
+        type: typeof raw.type === "string" ? raw.type : fallback.type,
+        id: typeof raw.id === "string" ? raw.id : fallback.id,
+    };
+};
+
 /**
- * 从 localStorage 原始字符串解析设置（浅合并默认值）。
+ * 从 localStorage 原始字符串解析设置（字段级校验 + 脏值回退默认）。
  * 脏 JSON / 非对象回退 defaults；LABORATORY → AZURE；通知被拒时关闭开关。
  */
 export const parseStoredSettings = (
@@ -23,17 +69,46 @@ export const parseStoredSettings = (
     defaults: Settings,
     options: ParseStoredSettingsOptions = {},
 ): Settings => {
-    if (!saved) return { ...defaults };
+    if (!saved)
+        return { ...defaults, musicConfig: { ...defaults.musicConfig } };
 
     try {
         const parsed: unknown = JSON.parse(saved);
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return { ...defaults };
+            return {
+                ...defaults,
+                musicConfig: { ...defaults.musicConfig },
+            };
         }
 
+        const raw = parsed as Record<string, unknown>;
         const loadedSettings: Settings = {
-            ...defaults,
-            ...(parsed as Partial<Settings>),
+            workDuration: asPositiveIntMinutes(
+                raw.workDuration,
+                defaults.workDuration,
+            ),
+            shortBreakDuration: asPositiveIntMinutes(
+                raw.shortBreakDuration,
+                defaults.shortBreakDuration,
+            ),
+            longBreakDuration: asPositiveIntMinutes(
+                raw.longBreakDuration,
+                defaults.longBreakDuration,
+            ),
+            autoStartBreaks: asBoolean(
+                raw.autoStartBreaks,
+                defaults.autoStartBreaks,
+            ),
+            autoStartWork: asBoolean(raw.autoStartWork, defaults.autoStartWork),
+            soundEnabled: asBoolean(raw.soundEnabled, defaults.soundEnabled),
+            soundVolume: asSoundVolume(raw.soundVolume, defaults.soundVolume),
+            notificationsEnabled: asBoolean(
+                raw.notificationsEnabled,
+                defaults.notificationsEnabled,
+            ),
+            language: asLanguage(raw.language, defaults.language),
+            theme: asTheme(raw.theme, defaults.theme),
+            musicConfig: asMusicConfig(raw.musicConfig, defaults.musicConfig),
         };
 
         if (
@@ -43,13 +118,9 @@ export const parseStoredSettings = (
             loadedSettings.notificationsEnabled = false;
         }
 
-        // Theme Migration: legacy LABORATORY → AZURE
-        if ((loadedSettings.theme as string) === "LABORATORY") {
-            loadedSettings.theme = ThemePreset.AZURE;
-        }
-
         return loadedSettings;
-    } catch {
-        return { ...defaults };
+    } catch (e) {
+        console.error("Failed to load settings", e);
+        return { ...defaults, musicConfig: { ...defaults.musicConfig } };
     }
 };

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
         "useDefineForClassFields": true,
         "lib": ["ES2022", "DOM", "DOM.Iterable"],
         "module": "ESNext",
-        "types": ["vite/client", "vitest/globals"],
+        "types": ["vite/client"],
         "skipLibCheck": true,
 
         /* Bundler mode */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
         "useDefineForClassFields": true,
         "lib": ["ES2022", "DOM", "DOM.Iterable"],
         "module": "ESNext",
-        "types": ["vite/client"],
+        "types": ["vite/client", "vitest/globals"],
         "skipLibCheck": true,
 
         /* Bundler mode */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
@@ -105,4 +106,10 @@ export default defineConfig({
             },
         }),
     ],
+    test: {
+        environment: "jsdom",
+        setupFiles: "./src/test/setup.ts",
+        include: ["src/**/*.{test,spec}.{ts,tsx}"],
+        css: false,
+    },
 });


### PR DESCRIPTION
## Summary
- Add Vitest + `@testing-library/react` + jsdom with `pnpm test` / `test:watch`
- Cover `useShuffle`, `asyncPool`, `parseResponse`, `parseDurationInput` / `parseStoredSettings`, and `advancePomodoroState` (22 tests)
- Extract `src/utils/settings.ts` and `src/utils/pomodoroState.ts` for testable pure logic
- Hook `pnpm test` into CI; bump Node to `22.22.2` for jsdom 30; ignore `.codegraph/` / `.superpowers/`

Stacked on #179 (`chore/add-ci-workflow`).

## Test plan
- [ ] `pnpm test` → 22/22 green
- [ ] `pnpm lint && pnpm check && pnpm build`
- [ ] CI job runs Test step after Check
- [ ] Confirm settings load / pomodoro work→break→long-break still behave as before


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Vitest test suite for core pure logic, wires in pure helpers, and runs tests in CI. Also hardens settings parsing to avoid crashes from corrupt localStorage and migrates legacy theme values.

- **New Features**
  - Set up `vitest` with `@testing-library/react`, `@testing-library/jest-dom`, and `jsdom` (`pnpm test`, `pnpm run test:watch`).
  - 23 tests cover `useShuffle` (via public API), `asyncPool`, `musicApiAdapters.parseResponse`, `parseDurationInput`/`parseStoredSettings` (field-level validation, notification permission, theme migration), and `advancePomodoroState`.
  - Extracted `src/utils/settings.ts` and `src/utils/pomodoroState.ts`; updated `App`, `SettingsPanel`, and `Pomodoro` to use them.
  - CI runs `pnpm test` after Check; `vite.config.ts` sets jsdom env and setup file.

- **Dependencies**
  - Bump Node to `22.22.2` for `jsdom@30`.
  - Add dev deps: `vitest`, `@testing-library/dom`, `@testing-library/react`, `@testing-library/jest-dom`, `jsdom`.
  - `.gitignore` excludes `.codegraph/` and `.superpowers/`.

<sup>Written for commit 3ea6322e72eeb79a89f681ebc9ca55ef04747a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

