### PR TITLE
chore(ui): remove unused Select and empty MikuForegroundLayer

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -24,7 +24,7 @@
 ## 阶段 2：低成本清理（快速胜利，不改行为）
 
 - [x] **#13 移除未使用依赖** `lucide-react`、`react-use`。*S*
-- [ ] **#14 删除死代码** `ui/Input.tsx` 的 `Select`（同步 ui/index.ts 导出）、`MikuForegroundLayer` 空渲染（TerminalUI 中 MIKU 分支一并处理）。*S*
+- [x] **#14 删除死代码** `ui/Input.tsx` 的 `Select`（同步 ui/index.ts 导出）、`MikuForegroundLayer` 空渲染（TerminalUI 中 MIKU 分支一并处理）。*S*
 - [x] **#12 清理生产 console** —— 高频/调试日志改为 debug 级别或删除；Biome `noConsole` 规则可选开启（warn 级）。*S*
 - [ ] **#33 移除无效兜底** `PWAPrompt.tsx` 的 `|| "Close"`。*S*
 - [x] **#38 魔法数字入 constants**（连续错误阈值 5、MAX_TASKS、循环等，同 #28 前半）。*S*

--- a/src/components/TerminalUI.tsx
+++ b/src/components/TerminalUI.tsx
@@ -17,7 +17,6 @@ import {
     IndustrialGrid,
     MatrixRain,
     MikuBackgroundLayer,
-    MikuForegroundLayer,
     NeonGrid,
     OriginForeground,
     OriginGrid,
@@ -88,8 +87,6 @@ export const ForegroundLayer: React.FC<{ theme?: ThemePreset }> = ({
             return <IndustrialForeground />;
         case ThemePreset.AZURE:
             return <AzureForeground />;
-        case ThemePreset.MIKU:
-            return <MikuForegroundLayer />;
         default:
             return null;
     }

--- a/src/components/themes/MikuDecorations.tsx
+++ b/src/components/themes/MikuDecorations.tsx
@@ -196,17 +196,6 @@ export const MikuBackgroundLayer: React.FC = () => {
     );
 };
 
-// ========== 前景效果组件 ==========
-
-// Miku 前景层效果
-export const MikuForegroundLayer: React.FC = () => {
-    return (
-        <div className="fixed inset-0 pointer-events-none z-50">
-            {/* 前景层现在为空 */}
-        </div>
-    );
-};
-
 // ========== 装饰元素组件 ==========
 
 // Miku 角色图片装饰组件

--- a/src/components/themes/index.ts
+++ b/src/components/themes/index.ts
@@ -23,5 +23,4 @@ export {
 export {
     MikuBackgroundLayer,
     MikuDecorations,
-    MikuForegroundLayer,
 } from "./MikuDecorations";

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -11,19 +11,3 @@ export const Input: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = (
         <div className="absolute bottom-0 left-0 h-[1px] w-full bg-theme-primary scale-x-0 group-hover:scale-x-100 origin-left transition-transform duration-500"></div>
     </div>
 );
-
-export const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = (
-    props,
-) => (
-    <div className="relative">
-        <select
-            {...props}
-            className={`bg-theme-highlight/20 border border-theme-highlight text-theme-text font-ui-mono text-ui-sm leading-ui-none px-4 h-form-control focus:outline-none focus:border-theme-primary w-full appearance-none cursor-pointer hover:bg-theme-highlight/10 transition-colors ${props.className ?? ""}`}
-        >
-            {props.children}
-        </select>
-        <div className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-theme-primary text-ui-xs">
-            ▼
-        </div>
-    </div>
-);

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,5 +3,5 @@
  */
 
 export { Button } from "./Button";
-export { Input, Select } from "./Input";
+export { Input } from "./Input";
 export { Panel } from "./Panel";


### PR DESCRIPTION
## Summary
- Remove unused `Select` from `ui/Input.tsx` and barrel export
- Remove empty `MikuForegroundLayer` plus TerminalUI MIKU foreground branch / themes export
- Mark OPTIMIZATION_TODO #14 done

## Test plan
- [ ] `pnpm lint && pnpm check && pnpm build`
- [ ] Switch to MIKU theme — background/decorations still render; no empty foreground overlay
- [ ] Settings still use CustomSelect normally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused UI `Select` and the no-op `MikuForegroundLayer` to simplify theme rendering with no behavior change. MIKU theme visuals are unchanged; settings continue to use `CustomSelect`.

- **Refactors**
  - Removed `Select` from `ui/Input.tsx` and its export in `ui/index.ts`.
  - Deleted `MikuForegroundLayer` from `themes/MikuDecorations.tsx` and removed the MIKU foreground branch in `TerminalUI`.
  - Stopped exporting `MikuForegroundLayer` in `themes/index.ts` and checked off OPTIMIZATION_TODO #14 in docs.

<sup>Written for commit 97ac00d0fb984d18e24017a2aa22d976fdae7170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

