### PR TITLE
chore: strip debug console logs from production paths

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -25,7 +25,7 @@
 
 - [ ] **#13 移除未使用依赖** `lucide-react`、`react-use`。*S*
 - [ ] **#14 删除死代码** `ui/Input.tsx` 的 `Select`（同步 ui/index.ts 导出）、`MikuForegroundLayer` 空渲染（TerminalUI 中 MIKU 分支一并处理）。*S*
-- [ ] **#12 清理生产 console** —— 高频/调试日志改为 debug 级别或删除；Biome `noConsole` 规则可选开启（warn 级）。*S*
+- [x] **#12 清理生产 console** —— 高频/调试日志改为 debug 级别或删除；Biome `noConsole` 规则可选开启（warn 级）。*S*
 - [ ] **#33 移除无效兜底** `PWAPrompt.tsx` 的 `|| "Close"`。*S*
 - [ ] **#38 魔法数字入 constants**（连续错误阈值 5、MAX_TASKS、循环等，同 #28 前半）。*S*
 - [ ] **#30 修正注释数值不一致** `useFooterHeight.ts`。*S*

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,10 @@ export default defineConfig([
             ecmaVersion: 2020,
             globals: globals.browser,
         },
+        rules: {
+            // 禁止调试日志进生产；保留 warn/error 供真实故障排查
+            "no-console": ["warn", { allow: ["warn", "error"] }],
+        },
     },
     {
         // useOnlinePlayer 将 HTMLAudioElement 存于 state（实例交换 Swap 需触发重渲染），

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -79,18 +79,11 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
             const track = metingData[index];
             if (!track || !track.id) return null;
 
-            console.log(
-                `[MusicPlayer] Attempting single-track fallback for: ${track.name} (id: ${track.id})`,
-            );
-
             const newUrl = await fetchTrackUrl(track.id, controller.signal);
 
             if (controller.signal.aborted) return null;
 
             if (newUrl) {
-                console.log(
-                    `[MusicPlayer] Track fallback successful. New URL: ${newUrl}`,
-                );
                 // 修复成功，重置错误计数
                 errorCountRef.current = 0;
 

--- a/src/components/PWAPrompt.tsx
+++ b/src/components/PWAPrompt.tsx
@@ -27,13 +27,11 @@ export function PWAPrompt({ language }: PWAPromptProps) {
 
                 // 立即检查一次
                 r.update();
-                console.log("[PWA] Registered & Initial check fired");
 
                 // 设置轮询 (每小时)
                 if (intervalRef.current) clearInterval(intervalRef.current);
 
                 intervalRef.current = window.setInterval(() => {
-                    console.log("[PWA] Hourly check fired");
                     r.update();
                 }, HOURLY_CHECK_INTERVAL_MS);
             }
@@ -61,9 +59,6 @@ export function PWAPrompt({ language }: PWAPromptProps) {
                 return;
             }
 
-            console.log(
-                "[PWA] Controller changed, showing update notification...",
-            );
             setShowUpdated(true);
         };
 
@@ -98,7 +93,6 @@ export function PWAPrompt({ language }: PWAPromptProps) {
                 return;
             }
             lastVisibilityCheckRef.current = now;
-            console.log("[PWA] Visibility visible, checking update...");
             registration.update();
         };
 

--- a/src/hooks/useLocalPlayer.ts
+++ b/src/hooks/useLocalPlayer.ts
@@ -287,9 +287,6 @@ export const useLocalPlayer = (enabled: boolean = true) => {
                     track.file.size === file.size &&
                     track.file.lastModified === file.lastModified,
             );
-            if (isDuplicate) {
-                console.warn(`Skip duplicate file: ${file.name}`);
-            }
             return !isDuplicate;
         });
 

--- a/src/hooks/useOnlinePlayer.ts
+++ b/src/hooks/useOnlinePlayer.ts
@@ -128,9 +128,6 @@ export const useOnlinePlayer = (
             // 如果是随机模式，则随机选择一首起始歌曲
             if (playMode === PlayMode.RANDOM) {
                 const randomIndex = Math.floor(Math.random() * playlist.length);
-                console.log(
-                    `[useOnlinePlayer] Initializing random index: ${randomIndex}`,
-                );
                 // 延迟到微任务中更新，避免在 effect 中同步 setState 触发级联渲染
                 queueMicrotask(() => setCurrentIndex(randomIndex));
             }
@@ -212,12 +209,6 @@ export const useOnlinePlayer = (
         const handleError = () => {
             setIsLoading(false);
             console.error("Online playback error: Load failed");
-            try {
-                const code = audio.error?.code;
-                if (code) console.warn("Audio error code:", code);
-            } catch {
-                void 0;
-            }
 
             const currentOnTrackFix = onTrackFixRef.current;
             const currentIsPlaying = isPlayingRef.current;
@@ -233,7 +224,6 @@ export const useOnlinePlayer = (
                     trackRetryRef.current.id !== currentTrackId ||
                     !trackRetryRef.current.fixed
                 ) {
-                    console.log("Attempting track fallback fix...");
                     // 尝试修复时，暂时清除错误状态，避免触发上层整单回退
                     setError(null);
                     trackRetryRef.current = {
@@ -246,9 +236,6 @@ export const useOnlinePlayer = (
                         .then((newUrl) => {
                             if (!isMounted) return;
                             if (newUrl) {
-                                console.log(
-                                    "Track fix successful, retrying with new URL",
-                                );
                                 // URL 覆盖将通过播放列表状态传播
                                 // 但为了立即生效，直接应用到当前 audio 实例
                                 audio.src = newUrl;
@@ -410,7 +397,6 @@ export const useOnlinePlayer = (
 
                 // Only load if URL is different
                 if (preloadAudio.src !== nextSong.url) {
-                    console.log(`Preloading next track: ${nextSong.name}`);
                     preloadAudio.src = nextSong.url;
                     preloadAudio.preload = "auto";
                     preloadAudio.load();
@@ -452,7 +438,6 @@ export const useOnlinePlayer = (
             preloadAudioRef.current &&
             preloadAudioRef.current.src === currentSong.url
         ) {
-            console.log("Instant play: Swapping audio instance");
             const newMain = preloadAudioRef.current;
             const oldMain = audioInstance;
 
@@ -489,9 +474,6 @@ export const useOnlinePlayer = (
                                 err instanceof DOMException &&
                                 err.name === "AbortError"
                             ) {
-                                console.log(
-                                    "Playback aborted (rapid switching)",
-                                );
                                 return;
                             }
                             throw err;


### PR DESCRIPTION
## Summary
- Remove debug/high-frequency `console.log` (and a couple noisy warns) from PWA and players
- Keep `console.warn` / `console.error` for real failure paths
- Add ESLint `no-console` (warn, allow warn/error)
- Mark OPTIMIZATION_TODO #12 done

## Test plan
- [ ] `pnpm lint && pnpm check && pnpm build`
- [ ] Exercise online/local playback and PWA update path — no debug spam in console
- [ ] Confirm real failures still emit warn/error when forced (e.g. bad track URL)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove high-frequency debug console logs from PWA and players to keep production consoles clean while preserving real failure signals. Add ESLint `no-console` (warn; allows `warn`/`error`) to prevent future noise.

- **Refactors**
  - Removed `console.log` from `PWAPrompt`, `MusicPlayer`, `useOnlinePlayer`, and `useLocalPlayer`.
  - Kept `console.warn`/`console.error` on failure paths.
  - Marked optimization task #12 as done in docs.

<sup>Written for commit 59eaa87db888b4716943ba9744c6730df8c4b9f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

