### PR TITLE
chore(i18n): drop redundant Close fallback in PWAPrompt

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -26,7 +26,7 @@
 - [x] **#13 移除未使用依赖** `lucide-react`、`react-use`。*S*
 - [x] **#14 删除死代码** `ui/Input.tsx` 的 `Select`（同步 ui/index.ts 导出）、`MikuForegroundLayer` 空渲染（TerminalUI 中 MIKU 分支一并处理）。*S*
 - [x] **#12 清理生产 console** —— 高频/调试日志改为 debug 级别或删除；Biome `noConsole` 规则可选开启（warn 级）。*S*
-- [ ] **#33 移除无效兜底** `PWAPrompt.tsx` 的 `|| "Close"`。*S*
+- [x] **#33 移除无效兜底** `PWAPrompt.tsx` 的 `|| "Close"`。*S*
 - [x] **#38 魔法数字入 constants**（连续错误阈值 5、MAX_TASKS、循环等，同 #28 前半）。*S*
 - [ ] **#30 修正注释数值不一致** `useFooterHeight.ts`。*S*
 - [ ] **#29 裁剪未消费的 hook 返回字段**（useSessionStats / useShuffle）。*S*

--- a/src/components/PWAPrompt.tsx
+++ b/src/components/PWAPrompt.tsx
@@ -126,8 +126,8 @@ export function PWAPrompt({ language }: PWAPromptProps) {
                 <button
                     onClick={() => setShowUpdated(false)}
                     className="p-1 hover:bg-theme-primary/10 rounded transition-colors group"
-                    aria-label={t("pwa_close") || "Close"}
-                    title={t("pwa_close") || "Close"}
+                    aria-label={t("pwa_close")}
+                    title={t("pwa_close")}
                 >
                     <i className="ri-close-line icon-ui-lg text-theme-text/60 group-hover:text-theme-text" />
                 </button>


### PR DESCRIPTION
## Summary
- Remove ineffective `t(\"pwa_close\") || \"Close\"` fallback from PWA update dismiss button
- Mark OPTIMIZATION_TODO #33 done

## Test plan
- [ ] Switch language CN/EN and trigger PWA updated toast — close button aria-label/title show 关闭 / Close
- [ ] `pnpm lint && pnpm check && pnpm build`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant "Close" fallback in `PWAPrompt` so the PWA update dismiss button uses `t('pwa_close')` for aria-label and title. Marked OPTIMIZATION_TODO #33 as done; no functional change since `pwa_close` exists in all locales and `t()` falls back to the key.

<sup>Written for commit 6e38d96f1bb49d38660130520bcccc80b69f4d6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

