### PR TITLE
chore: move MAX_TASKS and consecutive error limit into constants

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -27,7 +27,7 @@
 - [ ] **#14 删除死代码** `ui/Input.tsx` 的 `Select`（同步 ui/index.ts 导出）、`MikuForegroundLayer` 空渲染（TerminalUI 中 MIKU 分支一并处理）。*S*
 - [ ] **#12 清理生产 console** —— 高频/调试日志改为 debug 级别或删除；Biome `noConsole` 规则可选开启（warn 级）。*S*
 - [ ] **#33 移除无效兜底** `PWAPrompt.tsx` 的 `|| "Close"`。*S*
-- [ ] **#38 魔法数字入 constants**（连续错误阈值 5、MAX_TASKS、循环等，同 #28 前半）。*S*
+- [x] **#38 魔法数字入 constants**（连续错误阈值 5、MAX_TASKS、循环等，同 #28 前半）。*S*
 - [ ] **#30 修正注释数值不一致** `useFooterHeight.ts`。*S*
 - [ ] **#29 裁剪未消费的 hook 返回字段**（useSessionStats / useShuffle）。*S*
 

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { STORAGE_KEYS } from "../constants";
+import { MAX_TASKS, STORAGE_KEYS } from "../constants";
 import type { Task } from "../types";
 import { Language } from "../types";
 import { useTranslation } from "../utils/i18n";
@@ -8,8 +8,6 @@ import { Button, Input, Panel } from "./ui";
 interface TaskManagerProps {
     language: Language;
 }
-
-const MAX_TASKS = 6;
 
 const TaskManager: React.FC<TaskManagerProps> = ({ language }) => {
     const t = useTranslation(language);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,6 +57,7 @@ export const TIME_UPDATE_THROTTLE_SECONDS = 0.25; // 时间更新节流阈值（
 export const RESUME_TIME_BUFFER_SECONDS = 0.2; // 修复音轨后恢复播放时的时间回退缓冲（秒）
 export const API_FETCH_DELAY_MS = 100; // API 数据获取延迟（毫秒），减少初始加载卡顿
 export const API_TIMEOUT_MS = 5000; // API 请求超时时间（毫秒）
+export const ONLINE_CONSECUTIVE_ERROR_LIMIT = 5; // 在线播放连续加载失败达到该次数后停止自动切歌
 
 /**
  * 时间转换常量
@@ -81,6 +82,14 @@ export const VISIBILITY_CHECK_MIN_INTERVAL_MS = 30 * 60 * 1000; // 页面从隐�
  */
 export const TIMER_CHECK_INTERVAL_MS = 100; // 计时器精度检查间隔（毫秒）
 export const LONG_BREAK_INTERVAL = 4; // 每完成多少个工作会话后进入长休息
+
+/**
+ * 任务列表常量
+ *
+ * 使用位置：
+ * - TaskManager.tsx
+ */
+export const MAX_TASKS = 6; // 任务容量上限
 
 /**
  * 音效时长常量（秒）

--- a/src/hooks/useOnlinePlayer.ts
+++ b/src/hooks/useOnlinePlayer.ts
@@ -3,6 +3,7 @@ import { DEFAULT_MUSIC_VOLUME } from "../config/musicConfig";
 import {
     AUDIO_LOADING_TIMEOUT_MS,
     NEXT_TRACK_RETRY_DELAY_MS,
+    ONLINE_CONSECUTIVE_ERROR_LIMIT,
     PRELOAD_DELAY_MS,
     RESUME_TIME_BUFFER_SECONDS,
     STORAGE_KEYS,
@@ -291,7 +292,9 @@ export const useOnlinePlayer = (
         const proceedToErrorHandling = () => {
             setError("Load failed"); // Set error state only when we give up or skip
             consecutiveErrorsRef.current += 1;
-            if (consecutiveErrorsRef.current >= 5) {
+            if (
+                consecutiveErrorsRef.current >= ONLINE_CONSECUTIVE_ERROR_LIMIT
+            ) {
                 console.error(
                     "Too many consecutive errors, stopping playback.",
                 );


### PR DESCRIPTION
## Summary
- Add `MAX_TASKS` and `ONLINE_CONSECUTIVE_ERROR_LIMIT` to `constants.ts`
- Wire TaskManager / useOnlinePlayer to the shared values
- Mark OPTIMIZATION_TODO #38 done

## Test plan
- [ ] `pnpm lint && pnpm check && pnpm build`
- [ ] Task list still caps at 6
- [ ] Online player still stops auto-advance after 5 consecutive load failures


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the task capacity and online-player error threshold into shared constants to remove magic numbers and keep behavior consistent. The task list still caps at 6, and playback stops auto-advance after 5 consecutive load failures.

- **Refactors**
  - Added `MAX_TASKS` and `ONLINE_CONSECUTIVE_ERROR_LIMIT` to `src/constants.ts`.
  - Updated `TaskManager` and `useOnlinePlayer` to use the shared constants.
  - Checked off optimization item `#38` in `docs/OPTIMIZATION_TODO.md`.

<sup>Written for commit 4a32b94fab97ab51d2145cd3e635fb36fd2a5e7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

