### PR TITLE
docs: fix getThemeExtraSpacing comment to match 120px Miku spacing

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -28,7 +28,7 @@
 - [x] **#12 清理生产 console** —— 高频/调试日志改为 debug 级别或删除；Biome `noConsole` 规则可选开启（warn 级）。*S*
 - [x] **#33 移除无效兜底** `PWAPrompt.tsx` 的 `|| "Close"`。*S*
 - [x] **#38 魔法数字入 constants**（连续错误阈值 5、MAX_TASKS、循环等，同 #28 前半）。*S*
-- [ ] **#30 修正注释数值不一致** `useFooterHeight.ts`。*S*
+- [x] **#30 修正注释数值不一致** `useFooterHeight.ts`。*S*
 - [ ] **#29 裁剪未消费的 hook 返回字段**（useSessionStats / useShuffle）。*S*
 
 ## 阶段 3：无障碍阻断项（真实用户可感知）

--- a/src/hooks/useFooterHeight.ts
+++ b/src/hooks/useFooterHeight.ts
@@ -30,7 +30,7 @@ export const useFooterHeight = () => {
  * @returns 额外间距像素值
  */
 export const getThemeExtraSpacing = (isMikuTheme: boolean): number => {
-    // Miku 主题需要为角色图片和 Logo 预留额外空间 (12px)
+    // Miku 主题需要为角色图片和 Logo 预留额外空间 (120px)
     // 其他主题也需要基础间距 (60px)
     return isMikuTheme ? 120 : 60;
 };


### PR DESCRIPTION
## Summary
- Correct `getThemeExtraSpacing` comment (12px → 120px) to match implementation
- Mark OPTIMIZATION_TODO #30 done

## Test plan
- [ ] Comment matches `isMikuTheme ? 120 : 60`
- [ ] No runtime behavior change


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `getThemeExtraSpacing` comment to 120px for the Miku theme (was 12px) to match the implementation. Marks OPTIMIZATION_TODO #30 complete with no runtime changes.

<sup>Written for commit e964394288f80537d69525476b3b82298de3cfae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

