### PR TITLE
refactor(hooks): drop unused return fields from session and shuffle hooks

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -29,7 +29,7 @@
 - [x] **#33 移除无效兜底** `PWAPrompt.tsx` 的 `|| "Close"`。*S*
 - [x] **#38 魔法数字入 constants**（连续错误阈值 5、MAX_TASKS、循环等，同 #28 前半）。*S*
 - [x] **#30 修正注释数值不一致** `useFooterHeight.ts`。*S*
-- [ ] **#29 裁剪未消费的 hook 返回字段**（useSessionStats / useShuffle）。*S*
+- [x] **#29 裁剪未消费的 hook 返回字段**（useSessionStats / useShuffle）。*S*
 
 ## 阶段 3：无障碍阻断项（真实用户可感知）
 

--- a/src/hooks/useSessionStats.ts
+++ b/src/hooks/useSessionStats.ts
@@ -12,12 +12,6 @@ import { TimerMode } from "../types";
 type UseSessionStatsResult = {
     /** 当前已完成的番茄钟会话数量 */
     sessionCount: number;
-    /** 历史累计专注总时长（秒），不包含当前正在进行但未完成的会话 */
-    accumulatedSeconds: number;
-    /** 当前正在进行的会话已经过的时长（秒） */
-    elapsedSeconds: number;
-    /** 总专注时长 = 历史累计 + 当前已经过（秒） */
-    totalSeconds: number;
     /** 总专注时长（小时部分） */
     hours: number;
     /** 总专注时长（分钟部分） */
@@ -169,9 +163,6 @@ export const useSessionStats = (
 
     return {
         sessionCount,
-        accumulatedSeconds,
-        elapsedSeconds,
-        totalSeconds,
         hours,
         minutes,
         seconds,

--- a/src/hooks/useShuffle.ts
+++ b/src/hooks/useShuffle.ts
@@ -135,8 +135,6 @@ export const useShuffle = (
     }, [playlistLength, shuffledIndices, shufflePointer]);
 
     return {
-        shuffledIndices,
-        shufflePointer,
         getNextRandomIndex,
         getPrevRandomIndex,
         peekNextRandomIndex,


### PR DESCRIPTION
## Summary
- Stop returning unused \`accumulatedSeconds\` / \`elapsedSeconds\` / \`totalSeconds\` from \`useSessionStats\`
- Stop returning unused \`shuffledIndices\` / \`shufflePointer\` from \`useShuffle\`
- Mark OPTIMIZATION_TODO #29 done

Note: #180 tests were updated to use the public shuffle API only so this change stays compatible.

## Test plan
- [ ] \`pnpm lint && pnpm check && pnpm build\`
- [ ] Footer study time still updates while a work session runs
- [ ] Random play next/prev still works
- [ ] After #180 merge: \`pnpm test\` green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed unused return fields from `useSessionStats` and `useShuffle` to reduce the hook API surface and keep internals private. No behavior changes; stats display and shuffle navigation work as before.

- **Refactors**
  - `useSessionStats`: removed `accumulatedSeconds`, `elapsedSeconds`, `totalSeconds`.
  - `useShuffle`: removed `shuffledIndices`, `shufflePointer`.
  - Marked `OPTIMIZATION_TODO` item #29 as done.

<sup>Written for commit e8795f96218f20039faa787edf27ed42e614dec7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

