### PR TITLE
feat(robustness): stage 4 Error Boundary and music API URL encoding

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -46,10 +46,13 @@
 ## 阶段 4：健壮性与安全
 
 - [x] **#10 设置反序列化深校验** —— 字段级类型/范围校验（workDuration ≥1 整数等），脏字段回退默认值；复用 TaskManager 的校验写法。*S*
-- [ ] **#24 Error Boundary** —— 根部包一层错误边界 + 兜底 UI（PWA 白屏恢复路径）。*S*
-- [ ] **#22 API URL 参数编码** —— `buildUrl`/`buildTrackUrl` 中 `id`/`server`/`type` 经 `encodeURIComponent`（或 URLSearchParams）。*S*
-- [ ] **#23 CSP** —— 评估并添加 Content-Security-Policy（注意 Google Fonts 与第三方音频域白名单）。*S*
-- [ ] **#11 落地统一消息系统** —— 按 `docs/TODO.md` 既定计划执行（替换 alert/MessageDisplay/PWAPrompt 提示）。*M*
+- [x] **#24 Error Boundary** —— 根部包一层错误边界 + 兜底 UI（PWA 白屏恢复路径）。*S*
+- [x] **#22 API URL 参数编码** —— `buildUrl`/`buildTrackUrl` 中 `id`/`server`/`type` 经 `encodeURIComponent`（或 URLSearchParams）。*S*
+- [ ] **#23 CSP** —— ~~评估并添加 Content-Security-Policy~~ **不做**：个人/爱好向静态站，威胁模型弱；Fonts + 多域名音源/封面 + PWA 下 CSP 过紧易白屏，收益不抵运维成本。若以后上线强隔离再单独立项。*S*
+
+## 专项：统一消息系统（独立排期，不绑阶段 4）
+
+- [ ] **#11 落地统一消息系统** —— 按 `docs/TODO.md` 既定计划执行（替换 alert/MessageDisplay/PWAPrompt 提示）。与阶段 4 其它项解耦，单独开 PR。*M*
 
 ## 阶段 5：重构（依赖阶段 1 的测试兜底）
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,10 @@ import { useSessionStats } from "./hooks/useSessionStats";
 import type { Settings } from "./types";
 import { Language, ThemePreset, TimerMode, View } from "./types";
 import { useTranslation } from "./utils/i18n";
+import {
+    detectBrowserLanguage,
+    languageToHtmlLang,
+} from "./utils/languageLocale";
 import { parseStoredSettings } from "./utils/settings";
 
 const DEFAULT_SETTINGS: Settings = {
@@ -30,12 +34,7 @@ const DEFAULT_SETTINGS: Settings = {
     soundEnabled: true,
     soundVolume: 0.5,
     notificationsEnabled: false,
-    language: (() => {
-        const browserLangs = navigator.languages || [navigator.language];
-        return browserLangs.some((lang) => lang?.toLowerCase().startsWith("zh"))
-            ? Language.CN
-            : Language.EN;
-    })(),
+    language: detectBrowserLanguage(),
     theme: ThemePreset.INDUSTRIAL,
     musicConfig: defaultMusicConfig,
 };
@@ -160,8 +159,7 @@ const App: React.FC = () => {
 
     // 同步 html lang，供屏幕阅读器与浏览器拼写/翻译使用
     useEffect(() => {
-        document.documentElement.lang =
-            settings.language === Language.CN ? "zh-CN" : "en";
+        document.documentElement.lang = languageToHtmlLang(settings.language);
     }, [settings.language]);
 
     useEffect(() => {

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -95,7 +95,25 @@ describe("ErrorFallback", () => {
         expect(onReload).toHaveBeenCalledTimes(1);
     });
 
-    it("renders English copy from persisted settings", () => {
+    it("renders Chinese copy when html lang is zh-CN", () => {
+        document.documentElement.lang = "zh-CN";
+        render(<ErrorFallback onReload={() => {}} />);
+        expect(
+            screen.getByRole("button", { name: "刷新页面" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("系统异常")).toBeInTheDocument();
+    });
+
+    it("renders English copy when html lang is en", () => {
+        document.documentElement.lang = "en";
+        render(<ErrorFallback onReload={() => {}} />);
+        expect(
+            screen.getByRole("button", { name: "RELOAD" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("SYSTEM FAULT")).toBeInTheDocument();
+    });
+
+    it("renders English copy from persisted settings even if html lang is zh-CN", () => {
         window.localStorage.setItem(
             STORAGE_KEYS.SETTINGS,
             JSON.stringify({ language: Language.EN }),

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,5 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { STORAGE_KEYS } from "../constants";
+import { Language } from "../types";
 import { ErrorBoundary, ErrorFallback } from "./ErrorBoundary";
 
 const ThrowingChild = ({ message }: { message: string }) => {
@@ -9,7 +11,10 @@ const ThrowingChild = ({ message }: { message: string }) => {
 describe("ErrorBoundary", () => {
     afterEach(() => {
         cleanup();
+        vi.unstubAllGlobals();
         vi.restoreAllMocks();
+        window.localStorage.clear();
+        document.documentElement.lang = "zh-CN";
     });
 
     it("renders children when no error occurs", () => {
@@ -37,12 +42,47 @@ describe("ErrorBoundary", () => {
             }),
         ).toBeInTheDocument();
     });
+
+    it("reloads the page from the boundary recovery button", () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        const reload = vi.fn();
+        vi.stubGlobal("location", {
+            reload,
+            href: window.location.href,
+            assign: vi.fn(),
+            replace: vi.fn(),
+        });
+
+        render(
+            <ErrorBoundary>
+                <ThrowingChild message="boom" />
+            </ErrorBoundary>,
+        );
+
+        fireEvent.click(
+            screen.getByRole("button", { name: /刷新页面|RELOAD/i }),
+        );
+        expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    it("moves focus to the reload button after crash", () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        render(
+            <ErrorBoundary>
+                <ThrowingChild message="boom" />
+            </ErrorBoundary>,
+        );
+        expect(
+            screen.getByRole("button", { name: /刷新页面|RELOAD/i }),
+        ).toHaveFocus();
+    });
 });
 
 describe("ErrorFallback", () => {
     afterEach(() => {
         cleanup();
         vi.restoreAllMocks();
+        window.localStorage.clear();
         document.documentElement.lang = "zh-CN";
     });
 
@@ -53,5 +93,19 @@ describe("ErrorFallback", () => {
         render(<ErrorFallback onReload={onReload} />);
         fireEvent.click(screen.getByRole("button", { name: "刷新页面" }));
         expect(onReload).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders English copy from persisted settings", () => {
+        window.localStorage.setItem(
+            STORAGE_KEYS.SETTINGS,
+            JSON.stringify({ language: Language.EN }),
+        );
+        document.documentElement.lang = "zh-CN";
+
+        render(<ErrorFallback onReload={() => {}} />);
+        expect(
+            screen.getByRole("button", { name: "RELOAD" }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("SYSTEM FAULT")).toBeInTheDocument();
     });
 });

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ErrorBoundary, ErrorFallback } from "./ErrorBoundary";
+
+const ThrowingChild = ({ message }: { message: string }) => {
+    throw new Error(message);
+};
+
+describe("ErrorBoundary", () => {
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+    });
+
+    it("renders children when no error occurs", () => {
+        render(
+            <ErrorBoundary>
+                <div>ok</div>
+            </ErrorBoundary>,
+        );
+        expect(screen.getByText("ok")).toBeInTheDocument();
+    });
+
+    it("shows fallback UI when a child throws during render", () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+
+        render(
+            <ErrorBoundary>
+                <ThrowingChild message="boom" />
+            </ErrorBoundary>,
+        );
+
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: /刷新页面|RELOAD/i,
+            }),
+        ).toBeInTheDocument();
+    });
+});
+
+describe("ErrorFallback", () => {
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+        document.documentElement.lang = "zh-CN";
+    });
+
+    it("calls onReload when the reload button is pressed", () => {
+        const onReload = vi.fn();
+        document.documentElement.lang = "zh-CN";
+
+        render(<ErrorFallback onReload={onReload} />);
+        fireEvent.click(screen.getByRole("button", { name: "刷新页面" }));
+        expect(onReload).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Language } from "../types";
+import React, { useEffect, useRef } from "react";
 import { translations } from "../utils/i18n";
+import { resolveFallbackLanguage } from "../utils/resolveFallbackLanguage";
 import { Button } from "./ui/Button";
 
 type ErrorBoundaryProps = {
@@ -11,11 +11,6 @@ type ErrorBoundaryState = {
     error: Error | null;
 };
 
-const resolveFallbackLanguage = (): Language => {
-    const lang = document.documentElement.lang?.toLowerCase() ?? "";
-    return lang.startsWith("zh") ? Language.CN : Language.EN;
-};
-
 type ErrorFallbackProps = {
     onReload: () => void;
 };
@@ -24,6 +19,11 @@ type ErrorFallbackProps = {
 export const ErrorFallback: React.FC<ErrorFallbackProps> = ({ onReload }) => {
     const language = resolveFallbackLanguage();
     const t = translations[language];
+    const reloadRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        reloadRef.current?.focus();
+    }, []);
 
     return (
         <div
@@ -43,7 +43,12 @@ export const ErrorFallback: React.FC<ErrorFallbackProps> = ({ onReload }) => {
                     {t.ERROR_BOUNDARY_MESSAGE}
                 </p>
             </div>
-            <Button type="button" variant="primary" onClick={onReload}>
+            <Button
+                ref={reloadRef}
+                type="button"
+                variant="primary"
+                onClick={onReload}
+            >
                 {t.ERROR_BOUNDARY_RELOAD}
             </Button>
         </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Language } from "../types";
+import { translations } from "../utils/i18n";
+import { Button } from "./ui/Button";
+
+type ErrorBoundaryProps = {
+    children: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+    error: Error | null;
+};
+
+const resolveFallbackLanguage = (): Language => {
+    const lang = document.documentElement.lang?.toLowerCase() ?? "";
+    return lang.startsWith("zh") ? Language.CN : Language.EN;
+};
+
+type ErrorFallbackProps = {
+    onReload: () => void;
+};
+
+/** 根错误兜底：不依赖 App 状态，避免主题/设置本身挂掉时无法恢复 */
+export const ErrorFallback: React.FC<ErrorFallbackProps> = ({ onReload }) => {
+    const language = resolveFallbackLanguage();
+    const t = translations[language];
+
+    return (
+        <div
+            className="min-h-[100dvh] bg-theme-base text-theme-text font-ui-sans flex flex-col items-center justify-center gap-6 px-6 text-center"
+            role="alert"
+            aria-live="assertive"
+        >
+            <div className="flex flex-col items-center gap-2 max-w-md">
+                <i
+                    className="ri-error-warning-line icon-ui-display text-theme-primary"
+                    aria-hidden="true"
+                />
+                <h1 className="text-ui-xl font-ui-mono font-bold tracking-ui-wider uppercase">
+                    {t.ERROR_BOUNDARY_TITLE}
+                </h1>
+                <p className="text-ui-sm text-theme-dim font-ui-mono leading-relaxed">
+                    {t.ERROR_BOUNDARY_MESSAGE}
+                </p>
+            </div>
+            <Button type="button" variant="primary" onClick={onReload}>
+                {t.ERROR_BOUNDARY_RELOAD}
+            </Button>
+        </div>
+    );
+};
+
+/**
+ * 根级错误边界：捕获渲染期异常，避免 PWA/白屏无法恢复。
+ * 恢复路径仅 reload（不清 localStorage，保留设置与会话数据）。
+ */
+export class ErrorBoundary extends React.Component<
+    ErrorBoundaryProps,
+    ErrorBoundaryState
+> {
+    state: ErrorBoundaryState = { error: null };
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { error };
+    }
+
+    componentDidCatch(error: Error, info: React.ErrorInfo) {
+        console.error("[ErrorBoundary]", error, info.componentStack);
+    }
+
+    private handleReload = () => {
+        window.location.reload();
+    };
+
+    render() {
+        if (this.state.error) {
+            return <ErrorFallback onReload={this.handleReload} />;
+        }
+        return this.props.children;
+    }
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,31 +1,36 @@
 import React from "react";
 
-export const Button: React.FC<
-    React.ButtonHTMLAttributes<HTMLButtonElement> & {
-        variant?: "primary" | "secondary" | "danger" | "ghost";
-    }
-> = ({ children, variant = "primary", className = "", ...props }) => {
-    const baseStyle =
-        "font-ui-mono uppercase tracking-ui-wider text-ui-sm leading-ui-none px-3 md:px-6 min-h-form-control transition-all duration-200 inline-flex items-center justify-center gap-2 relative group disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer overflow-hidden whitespace-nowrap active:scale-95";
-
-    const variants = {
-        primary:
-            "bg-theme-primary text-theme-base hover:bg-theme-primary/90 hover:shadow-[0_0_15px_rgba(var(--color-primary),0.4)] clip-path-slant font-bold",
-        secondary:
-            "bg-transparent text-theme-primary border border-theme-primary hover:bg-theme-primary/10",
-        danger: "bg-red-900/20 text-red-500 border border-red-900 hover:bg-red-900/40",
-        ghost: "bg-transparent text-theme-text hover:text-theme-primary hover:bg-theme-highlight/10",
-    };
-
-    return (
-        <button
-            className={`${baseStyle} ${variants[variant]} ${className}`}
-            {...props}
-        >
-            <span className="relative z-10 flex items-center gap-2">
-                {children}
-            </span>
-            <div className="absolute inset-0 bg-white/10 translate-y-full group-hover:translate-y-0 transition-transform duration-300"></div>
-        </button>
-    );
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: "primary" | "secondary" | "danger" | "ghost";
 };
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({ children, variant = "primary", className = "", ...props }, ref) => {
+        const baseStyle =
+            "font-ui-mono uppercase tracking-ui-wider text-ui-sm leading-ui-none px-3 md:px-6 min-h-form-control transition-all duration-200 inline-flex items-center justify-center gap-2 relative group disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer overflow-hidden whitespace-nowrap active:scale-95";
+
+        const variants = {
+            primary:
+                "bg-theme-primary text-theme-base hover:bg-theme-primary/90 hover:shadow-[0_0_15px_rgba(var(--color-primary),0.4)] clip-path-slant font-bold",
+            secondary:
+                "bg-transparent text-theme-primary border border-theme-primary hover:bg-theme-primary/10",
+            danger: "bg-red-900/20 text-red-500 border border-red-900 hover:bg-red-900/40",
+            ghost: "bg-transparent text-theme-text hover:text-theme-primary hover:bg-theme-highlight/10",
+        };
+
+        return (
+            <button
+                ref={ref}
+                className={`${baseStyle} ${variants[variant]} ${className}`}
+                {...props}
+            >
+                <span className="relative z-10 flex items-center gap-2">
+                    {children}
+                </span>
+                <div className="absolute inset-0 bg-white/10 translate-y-full group-hover:translate-y-0 transition-transform duration-300"></div>
+            </button>
+        );
+    },
+);
+
+Button.displayName = "Button";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { syncDocumentLanguageBeforeApp } from "./utils/resolveFallbackLanguage";
 import "./index.css";
 import "remixicon/fonts/remixicon.css";
+
+// 挂载前同步 html lang，缩小首屏崩溃时语言错位窗口
+syncDocumentLanguageBeforeApp();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./index.css";
 import "remixicon/fonts/remixicon.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
-        <App />
+        <ErrorBoundary>
+            <App />
+        </ErrorBoundary>
     </React.StrictMode>,
 );

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,45 @@
 import "@testing-library/jest-dom/vitest";
+
+/**
+ * Node 22+/26 可能抢占全局 localStorage 名但未启用实现，
+ * 导致 jsdom 的 window.localStorage 为 undefined。测试里补一个内存 Storage。
+ */
+const installMemoryLocalStorage = () => {
+    if (typeof window === "undefined") return;
+    if (
+        window.localStorage &&
+        typeof window.localStorage.getItem === "function"
+    ) {
+        return;
+    }
+
+    const store = new Map<string, string>();
+    const memoryStorage: Storage = {
+        get length() {
+            return store.size;
+        },
+        clear() {
+            store.clear();
+        },
+        getItem(key: string) {
+            return store.has(key) ? store.get(key)! : null;
+        },
+        key(index: number) {
+            return Array.from(store.keys())[index] ?? null;
+        },
+        removeItem(key: string) {
+            store.delete(key);
+        },
+        setItem(key: string, value: string) {
+            store.set(key, String(value));
+        },
+    };
+
+    Object.defineProperty(window, "localStorage", {
+        configurable: true,
+        enumerable: true,
+        value: memoryStorage,
+    });
+};
+
+installMemoryLocalStorage();

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -124,6 +124,12 @@ export const translations = {
         VOLUME_SLIDER: "Volume",
         CLOSE_PLAYLIST: "Close playlist",
 
+        // Error Boundary
+        ERROR_BOUNDARY_TITLE: "SYSTEM FAULT",
+        ERROR_BOUNDARY_MESSAGE:
+            "The interface crashed. Reload to restore the session.",
+        ERROR_BOUNDARY_RELOAD: "RELOAD",
+
         // PWA
         pwa_updated: "Update ready. Refresh to apply.",
         pwa_offline: "OFFLINE MODE",
@@ -258,6 +264,11 @@ export const translations = {
         PROGRESS_SLIDER: "播放进度",
         VOLUME_SLIDER: "音量",
         CLOSE_PLAYLIST: "关闭播放列表",
+
+        // Error Boundary
+        ERROR_BOUNDARY_TITLE: "系统异常",
+        ERROR_BOUNDARY_MESSAGE: "界面发生错误。刷新页面可恢复会话。",
+        ERROR_BOUNDARY_RELOAD: "刷新页面",
 
         // PWA
         pwa_updated: "新版本已就绪，刷新后生效。",

--- a/src/utils/languageLocale.test.ts
+++ b/src/utils/languageLocale.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { Language } from "../types";
+import {
+    detectBrowserLanguage,
+    htmlLangToLanguage,
+    languageToHtmlLang,
+} from "./languageLocale";
+
+describe("languageLocale", () => {
+    it("maps Language to html lang and back", () => {
+        expect(languageToHtmlLang(Language.CN)).toBe("zh-CN");
+        expect(languageToHtmlLang(Language.EN)).toBe("en");
+        expect(htmlLangToLanguage("zh-CN")).toBe(Language.CN);
+        expect(htmlLangToLanguage("zh")).toBe(Language.CN);
+        expect(htmlLangToLanguage("en")).toBe(Language.EN);
+        expect(htmlLangToLanguage("en-US")).toBe(Language.EN);
+        expect(htmlLangToLanguage("")).toBe(Language.EN);
+    });
+
+    it("detects browser language like App defaults", () => {
+        expect(typeof detectBrowserLanguage()).toBe("string");
+        expect([Language.CN, Language.EN]).toContain(detectBrowserLanguage());
+    });
+});

--- a/src/utils/languageLocale.ts
+++ b/src/utils/languageLocale.ts
@@ -1,0 +1,25 @@
+import { Language } from "../types";
+
+/** App / ErrorBoundary 共用的 Language ↔ html lang 映射 */
+export const languageToHtmlLang = (language: Language): string =>
+    language === Language.CN ? "zh-CN" : "en";
+
+export const htmlLangToLanguage = (
+    htmlLang: string | null | undefined,
+): Language => {
+    const lang = htmlLang?.toLowerCase() ?? "";
+    return lang.startsWith("zh") ? Language.CN : Language.EN;
+};
+
+/** 与 App DEFAULT_SETTINGS.language 相同的浏览器语言推断 */
+export const detectBrowserLanguage = (): Language => {
+    const browserLangs =
+        typeof navigator !== "undefined"
+            ? navigator.languages?.length
+                ? navigator.languages
+                : [navigator.language]
+            : [];
+    return browserLangs.some((lang) => lang?.toLowerCase().startsWith("zh"))
+        ? Language.CN
+        : Language.EN;
+};

--- a/src/utils/musicApiAdapters.test.ts
+++ b/src/utils/musicApiAdapters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { metingAdapter } from "./musicApiAdapters";
+import { metingAdapter, metingFallbackAdapter } from "./musicApiAdapters";
 
 describe("metingAdapter.parseResponse", () => {
     it("maps primary fields", () => {
@@ -55,6 +55,42 @@ describe("metingAdapter.parseResponse", () => {
     it("throws on non-array", () => {
         expect(() => metingAdapter.parseResponse({ ok: true })).toThrow(
             "Empty playlist",
+        );
+    });
+});
+
+describe("music API URL builders", () => {
+    it("encodes reserved characters in playlist query params", () => {
+        const url = metingAdapter.buildUrl({
+            server: "netease",
+            type: "playlist",
+            id: "a&b=c d",
+        });
+        const parsed = new URL(url);
+        expect(parsed.origin + parsed.pathname).toBe(
+            "https://api.i-meto.com/meting/api",
+        );
+        expect(parsed.searchParams.get("server")).toBe("netease");
+        expect(parsed.searchParams.get("type")).toBe("playlist");
+        expect(parsed.searchParams.get("id")).toBe("a&b=c d");
+        expect(url).not.toContain("id=a&b=c");
+    });
+
+    it("encodes track URL params on both adapters", () => {
+        const primary = metingAdapter.buildTrackUrl!({
+            server: "tencent",
+            id: "song/1?x=1",
+        });
+        const fallback = metingFallbackAdapter.buildTrackUrl!({
+            server: "tencent",
+            id: "song/1?x=1",
+        });
+
+        expect(new URL(primary).searchParams.get("type")).toBe("song");
+        expect(new URL(primary).searchParams.get("id")).toBe("song/1?x=1");
+        expect(new URL(fallback).searchParams.get("id")).toBe("song/1?x=1");
+        expect(fallback.startsWith("https://api.injahow.cn/meting/?")).toBe(
+            true,
         );
     });
 });

--- a/src/utils/musicApiAdapters.test.ts
+++ b/src/utils/musicApiAdapters.test.ts
@@ -77,20 +77,33 @@ describe("music API URL builders", () => {
     });
 
     it("encodes track URL params on both adapters", () => {
+        const dirtyId = "song&id=1 x";
         const primary = metingAdapter.buildTrackUrl!({
             server: "tencent",
-            id: "song/1?x=1",
+            id: dirtyId,
         });
         const fallback = metingFallbackAdapter.buildTrackUrl!({
             server: "tencent",
-            id: "song/1?x=1",
+            id: dirtyId,
         });
 
         expect(new URL(primary).searchParams.get("type")).toBe("song");
-        expect(new URL(primary).searchParams.get("id")).toBe("song/1?x=1");
-        expect(new URL(fallback).searchParams.get("id")).toBe("song/1?x=1");
+        expect(new URL(primary).searchParams.get("id")).toBe(dirtyId);
+        expect(new URL(fallback).searchParams.get("id")).toBe(dirtyId);
+        expect(primary).not.toContain("id=song&id=");
+        expect(fallback).not.toContain("id=song&id=");
         expect(fallback.startsWith("https://api.injahow.cn/meting/?")).toBe(
             true,
         );
+    });
+
+    it("encodes reserved characters on fallback playlist URLs", () => {
+        const url = metingFallbackAdapter.buildUrl({
+            server: "netease",
+            type: "playlist",
+            id: "a&b=c d",
+        });
+        expect(new URL(url).searchParams.get("id")).toBe("a&b=c d");
+        expect(url).not.toContain("id=a&b=c");
     });
 });

--- a/src/utils/musicApiAdapters.ts
+++ b/src/utils/musicApiAdapters.ts
@@ -26,17 +26,24 @@ export interface MusicAPIAdapter {
     fetchOptions?: RequestInit;
 }
 
+const withQuery = (baseUrl: string, params: Record<string, string>): string => {
+    const query = new URLSearchParams(params).toString();
+    return `${baseUrl}?${query}`;
+};
+
 /**
  * Meting API 适配器（主）
  */
 export const metingAdapter: MusicAPIAdapter = {
-    buildUrl: ({ server, type, id }) => {
-        return `https://api.i-meto.com/meting/api?server=${server}&type=${type}&id=${id}`;
-    },
+    buildUrl: ({ server, type, id }) =>
+        withQuery("https://api.i-meto.com/meting/api", { server, type, id }),
 
-    buildTrackUrl: ({ server, id }) => {
-        return `https://api.i-meto.com/meting/api?server=${server}&type=song&id=${id}`;
-    },
+    buildTrackUrl: ({ server, id }) =>
+        withQuery("https://api.i-meto.com/meting/api", {
+            server,
+            type: "song",
+            id,
+        }),
 
     parseResponse: (data) => {
         if (!Array.isArray(data) || data.length === 0) {
@@ -58,13 +65,15 @@ export const metingAdapter: MusicAPIAdapter = {
  * Meting API 适配器（备用）
  */
 export const metingFallbackAdapter: MusicAPIAdapter = {
-    buildUrl: ({ server, type, id }) => {
-        return `https://api.injahow.cn/meting/?server=${server}&type=${type}&id=${id}`;
-    },
+    buildUrl: ({ server, type, id }) =>
+        withQuery("https://api.injahow.cn/meting/", { server, type, id }),
 
-    buildTrackUrl: ({ server, id }) => {
-        return `https://api.injahow.cn/meting/?server=${server}&type=song&id=${id}`;
-    },
+    buildTrackUrl: ({ server, id }) =>
+        withQuery("https://api.injahow.cn/meting/", {
+            server,
+            type: "song",
+            id,
+        }),
 
     parseResponse: metingAdapter.parseResponse,
 };

--- a/src/utils/resolveFallbackLanguage.test.ts
+++ b/src/utils/resolveFallbackLanguage.test.ts
@@ -1,12 +1,17 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { STORAGE_KEYS } from "../constants";
 import { Language } from "../types";
-import { resolveFallbackLanguage } from "./resolveFallbackLanguage";
+import {
+    readStoredLanguage,
+    resolveFallbackLanguage,
+    syncDocumentLanguageBeforeApp,
+} from "./resolveFallbackLanguage";
 
 describe("resolveFallbackLanguage", () => {
     afterEach(() => {
         window.localStorage.clear();
         document.documentElement.lang = "zh-CN";
+        vi.restoreAllMocks();
     });
 
     it("prefers persisted settings language over html lang", () => {
@@ -16,6 +21,7 @@ describe("resolveFallbackLanguage", () => {
         );
         document.documentElement.lang = "zh-CN";
         expect(resolveFallbackLanguage()).toBe(Language.EN);
+        expect(readStoredLanguage()).toBe(Language.EN);
     });
 
     it("falls back to html lang when settings are missing", () => {
@@ -23,5 +29,30 @@ describe("resolveFallbackLanguage", () => {
         expect(resolveFallbackLanguage()).toBe(Language.EN);
         document.documentElement.lang = "zh-CN";
         expect(resolveFallbackLanguage()).toBe(Language.CN);
+    });
+});
+
+describe("syncDocumentLanguageBeforeApp", () => {
+    afterEach(() => {
+        window.localStorage.clear();
+        document.documentElement.lang = "zh-CN";
+        vi.restoreAllMocks();
+    });
+
+    it("writes persisted language to html lang before app mount", () => {
+        window.localStorage.setItem(
+            STORAGE_KEYS.SETTINGS,
+            JSON.stringify({ language: Language.EN }),
+        );
+        document.documentElement.lang = "zh-CN";
+        syncDocumentLanguageBeforeApp();
+        expect(document.documentElement.lang).toBe("en");
+    });
+
+    it("uses browser language when nothing is stored", () => {
+        vi.spyOn(navigator, "languages", "get").mockReturnValue(["en-US"]);
+        document.documentElement.lang = "zh-CN";
+        syncDocumentLanguageBeforeApp();
+        expect(document.documentElement.lang).toBe("en");
     });
 });

--- a/src/utils/resolveFallbackLanguage.test.ts
+++ b/src/utils/resolveFallbackLanguage.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { STORAGE_KEYS } from "../constants";
+import { Language } from "../types";
+import { resolveFallbackLanguage } from "./resolveFallbackLanguage";
+
+describe("resolveFallbackLanguage", () => {
+    afterEach(() => {
+        window.localStorage.clear();
+        document.documentElement.lang = "zh-CN";
+    });
+
+    it("prefers persisted settings language over html lang", () => {
+        window.localStorage.setItem(
+            STORAGE_KEYS.SETTINGS,
+            JSON.stringify({ language: Language.EN }),
+        );
+        document.documentElement.lang = "zh-CN";
+        expect(resolveFallbackLanguage()).toBe(Language.EN);
+    });
+
+    it("falls back to html lang when settings are missing", () => {
+        document.documentElement.lang = "en";
+        expect(resolveFallbackLanguage()).toBe(Language.EN);
+        document.documentElement.lang = "zh-CN";
+        expect(resolveFallbackLanguage()).toBe(Language.CN);
+    });
+});

--- a/src/utils/resolveFallbackLanguage.ts
+++ b/src/utils/resolveFallbackLanguage.ts
@@ -1,9 +1,14 @@
 import { STORAGE_KEYS } from "../constants";
 import { Language } from "../types";
+import {
+    detectBrowserLanguage,
+    htmlLangToLanguage,
+    languageToHtmlLang,
+} from "./languageLocale";
 
 const LANGUAGE_VALUES = new Set<string>(Object.values(Language));
 
-const readStoredLanguage = (): Language | null => {
+export const readStoredLanguage = (): Language | null => {
     try {
         // 显式用 window.localStorage，避免 Node 全局 localStorage 未启用时读到 undefined
         const raw = window.localStorage.getItem(STORAGE_KEYS.SETTINGS);
@@ -21,13 +26,23 @@ const readStoredLanguage = (): Language | null => {
 };
 
 /**
- * 优先读已持久化的语言设置（首屏崩溃时 App 的 lang effect 可能还没跑）；
- * 再回退到 documentElement.lang / 英文。
+ * 兜底语言优先级：
+ * 1) 已持久化设置
+ * 2) 当前 html lang（main 在挂载前已按存储/浏览器同步）
  */
 export const resolveFallbackLanguage = (): Language => {
     const stored = readStoredLanguage();
     if (stored) return stored;
+    return htmlLangToLanguage(document.documentElement.lang);
+};
 
-    const lang = document.documentElement.lang?.toLowerCase() ?? "";
-    return lang.startsWith("zh") ? Language.CN : Language.EN;
+/**
+ * 在挂载 React 前同步 <html lang>：
+ * - 有持久化设置 → 用设置
+ * - 否则 → 与 App DEFAULT_SETTINGS 相同的浏览器推断
+ * 避免「index.html 写死 zh-CN + 英文用户首屏崩溃」错成中文兜底。
+ */
+export const syncDocumentLanguageBeforeApp = (): void => {
+    const language = readStoredLanguage() ?? detectBrowserLanguage();
+    document.documentElement.lang = languageToHtmlLang(language);
 };

--- a/src/utils/resolveFallbackLanguage.ts
+++ b/src/utils/resolveFallbackLanguage.ts
@@ -1,0 +1,33 @@
+import { STORAGE_KEYS } from "../constants";
+import { Language } from "../types";
+
+const LANGUAGE_VALUES = new Set<string>(Object.values(Language));
+
+const readStoredLanguage = (): Language | null => {
+    try {
+        // 显式用 window.localStorage，避免 Node 全局 localStorage 未启用时读到 undefined
+        const raw = window.localStorage.getItem(STORAGE_KEYS.SETTINGS);
+        if (!raw) return null;
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== "object") return null;
+        const language = (parsed as { language?: unknown }).language;
+        if (typeof language === "string" && LANGUAGE_VALUES.has(language)) {
+            return language as Language;
+        }
+    } catch {
+        // 损坏的 settings / 无 storage 不影响兜底 UI
+    }
+    return null;
+};
+
+/**
+ * 优先读已持久化的语言设置（首屏崩溃时 App 的 lang effect 可能还没跑）；
+ * 再回退到 documentElement.lang / 英文。
+ */
+export const resolveFallbackLanguage = (): Language => {
+    const stored = readStoredLanguage();
+    if (stored) return stored;
+
+    const lang = document.documentElement.lang?.toLowerCase() ?? "";
+    return lang.startsWith("zh") ? Language.CN : Language.EN;
+};


### PR DESCRIPTION
## Summary
- Add a root `ErrorBoundary` with reload fallback so PWA white-screen crashes can recover without wiping settings
- Encode `buildUrl` / `buildTrackUrl` query params via `URLSearchParams` (covers reserved characters in playlist/song IDs)
- Update optimization TODO: mark CSP (#23) as wontfix; move unified messaging (#11) out of stage 4 as a separate track

## Test plan
- [ ] `pnpm lint && pnpm check && pnpm test && pnpm build`
- [ ] Force a render crash (temporary throw in `App`) → fallback UI appears → Reload restores the app
- [ ] Online music still loads with default playlist ID
- [ ] Confirm zh/en fallback copy follows `document.documentElement.lang`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a root Error Boundary with a reloadable fallback to recover PWA white screens without losing settings. Syncs language before mount and encodes music API URLs to prevent crashes and bad requests.

- **New Features**
  - Wrap `App` with `ErrorBoundary`; fallback language prefers persisted settings, otherwise `document.documentElement.lang`; reload keeps session and the reload button is focused. (Linear #24)
  - Sync `<html lang>` before React mounts and share locale mapping helpers so crash UI always matches the user's language. (Linear #24)
  - Use `URLSearchParams` for `metingAdapter` and `metingFallbackAdapter` `buildUrl`/`buildTrackUrl` to encode `server`/`type`/`id`. (Linear #22)

- **Refactors**
  - Update optimization plan: mark CSP (Linear #23) as wontfix; move unified messaging (Linear #11) to a separate track.

<sup>Written for commit 72e71e3690391db0062de1e4898c9ac474646d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

