### PR TITLE
feat(music): enhance music data handling and player robustness

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -70,7 +70,7 @@
 - [ ] **#32 keyframes 收敛** —— 重复 `scan` 及散落 `<style>` 统一迁入 index.css。*S*
 - [ ] **#28 后半 任务 id** —— `Date.now()` → `crypto.randomUUID()`。*S*
 - [ ] **#39 统计语义确认** —— sessionStorage vs localStorage 的"累计时长"语义，确认后写入 README/注释。*S*
-- [ ] **#40 CHANGELOG.md** —— 建立变更记录（可从 git tag 历史回填）。*S*
+
 
 ## 专项（全部阶段之后）：统一消息系统
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -6,7 +6,7 @@ import React, {
     useState,
 } from "react";
 import { createPortal } from "react-dom";
-import type { MusicConfig } from "../config/musicConfig";
+import { type MusicConfig, musicSourceKey } from "../config/musicConfig";
 import { STORAGE_KEYS, TOAST_DURATION_MS } from "../constants";
 import { useLocalPlayer } from "../hooks/useLocalPlayer";
 import { useModalA11y } from "../hooks/useModalA11y";
@@ -166,7 +166,14 @@ const AudioPlayer: React.FC<{
             )}
 
             {audioSource === "online" ? (
-                <MusicPlayer config={musicConfig} language={language} enabled />
+                <MusicPlayer
+                    // 换歌单即换播放上下文：用 key 重建播放器，
+                    // 让播放位置/进度/播放状态一并重置（React 官方推荐的状态重置方式）
+                    key={musicSourceKey(musicConfig)}
+                    config={musicConfig}
+                    language={language}
+                    enabled
+                />
             ) : (
                 <>
                     <input

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { STORAGE_KEYS } from "../constants";
 import { Language } from "../types";
@@ -10,7 +10,6 @@ const ThrowingChild = ({ message }: { message: string }) => {
 
 describe("ErrorBoundary", () => {
     afterEach(() => {
-        cleanup();
         vi.unstubAllGlobals();
         vi.restoreAllMocks();
         window.localStorage.clear();
@@ -80,7 +79,6 @@ describe("ErrorBoundary", () => {
 
 describe("ErrorFallback", () => {
     afterEach(() => {
-        cleanup();
         vi.restoreAllMocks();
         window.localStorage.clear();
         document.documentElement.lang = "zh-CN";

--- a/src/components/MusicPlayer.test.tsx
+++ b/src/components/MusicPlayer.test.tsx
@@ -1,0 +1,174 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TRACK_FIX_FAILURE_LIMIT } from "../constants";
+import type { MusicTrack } from "../hooks/useMusicData";
+import { Language } from "../types";
+import MusicPlayer from "./MusicPlayer";
+
+type TrackFix = (index: number, currentUrl: string) => Promise<string | null>;
+
+const mocks = vi.hoisted(() => ({
+    audioList: [] as MusicTrack[],
+    loading: false,
+    retryWithNextAdapter: vi.fn(),
+    fetchTrackUrl: vi.fn<() => Promise<string | null>>(),
+    capturedTrackFix: undefined as TrackFix | undefined,
+    capturedEnabled: undefined as boolean | undefined,
+}));
+
+vi.mock("../hooks/useMusicData", () => ({
+    useMusicData: () => ({
+        audioList: mocks.audioList,
+        loading: mocks.loading,
+        error: null,
+        retryWithNextAdapter: mocks.retryWithNextAdapter,
+        activeAdapterIndex: 0,
+        fetchTrackUrl: mocks.fetchTrackUrl,
+    }),
+}));
+
+vi.mock("../hooks/useOnlinePlayer", () => ({
+    useOnlinePlayer: (
+        playlist: { name: string; artist: string; cover: string }[],
+        _autoPlay: boolean,
+        enabled: boolean,
+        onTrackFix?: TrackFix,
+    ) => {
+        mocks.capturedTrackFix = onTrackFix;
+        mocks.capturedEnabled = enabled;
+        return {
+            currentSong: playlist[0],
+            currentIndex: 0,
+            isPlaying: false,
+            currentTime: 0,
+            duration: 0,
+            volume: 0.5,
+            playMode: "sequence",
+            isLoading: false,
+            error: null,
+            togglePlay: vi.fn(),
+            handleNext: vi.fn(),
+            handlePrev: vi.fn(),
+            seek: vi.fn(),
+            setVolume: vi.fn(),
+            toggleMode: vi.fn(),
+            playTrack: vi.fn(),
+        };
+    },
+}));
+
+const renderPlayer = () =>
+    render(
+        <MusicPlayer
+            config={{ server: "netease", type: "playlist", id: "1" }}
+            language={Language.EN}
+        />,
+    );
+
+beforeEach(() => {
+    mocks.capturedTrackFix = undefined;
+    mocks.capturedEnabled = undefined;
+    mocks.loading = false;
+    mocks.retryWithNextAdapter.mockClear();
+    mocks.fetchTrackUrl.mockReset();
+});
+
+describe("MusicPlayer adapter downgrade path", () => {
+    it("switches adapters even when tracks carry no usable id", async () => {
+        // 上游不返回 id 且 url 也无法还原 id 时，单曲回退无从下手；
+        // 这曾经让失败计数被跳过，导致整单换源的降级路径永远不触发
+        mocks.audioList = [
+            {
+                id: "",
+                name: "No id track",
+                artist: "Artist",
+                url: "https://example.test/opaque.mp3",
+                cover: "",
+                lrc: "",
+            },
+        ];
+
+        renderPlayer();
+        expect(mocks.capturedTrackFix).toBeDefined();
+
+        for (let i = 0; i < TRACK_FIX_FAILURE_LIMIT; i += 1) {
+            await mocks.capturedTrackFix?.(
+                0,
+                "https://example.test/opaque.mp3",
+            );
+        }
+
+        expect(mocks.fetchTrackUrl).not.toHaveBeenCalled();
+        expect(mocks.retryWithNextAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it("switches adapters when per-track fallback keeps returning nothing", async () => {
+        mocks.audioList = [
+            {
+                id: "3322640395",
+                name: "Track",
+                artist: "Artist",
+                url: "https://api.injahow.cn/meting/?server=netease&type=url&id=3322640395",
+                cover: "",
+                lrc: "",
+            },
+        ];
+        mocks.fetchTrackUrl.mockResolvedValue(null);
+
+        renderPlayer();
+
+        for (let i = 0; i < TRACK_FIX_FAILURE_LIMIT; i += 1) {
+            await mocks.capturedTrackFix?.(0, "");
+        }
+
+        expect(mocks.fetchTrackUrl).toHaveBeenCalled();
+        expect(mocks.retryWithNextAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables the audio player while a playlist refetch is in flight", () => {
+        mocks.audioList = [
+            {
+                id: "1",
+                name: "Track",
+                artist: "Artist",
+                url: "https://example.test/a.mp3",
+                cover: "",
+                lrc: "",
+            },
+        ];
+
+        mocks.loading = false;
+        const { rerender } = renderPlayer();
+        expect(mocks.capturedEnabled).toBe(true);
+
+        // 切换适配器会重新拉取歌单，界面切到 CONNECTING；
+        // 播放器必须同时停下，否则会「显示正在连接却仍在放旧数据源」
+        mocks.loading = true;
+        rerender(
+            <MusicPlayer
+                config={{ server: "netease", type: "playlist", id: "1" }}
+                language={Language.EN}
+            />,
+        );
+
+        expect(mocks.capturedEnabled).toBe(false);
+    });
+
+    it("does not count an out-of-range index as a playback failure", async () => {
+        mocks.audioList = [
+            {
+                id: "1",
+                name: "Track",
+                artist: "Artist",
+                url: "https://example.test/a.mp3",
+                cover: "",
+                lrc: "",
+            },
+        ];
+
+        renderPlayer();
+
+        await expect(mocks.capturedTrackFix?.(99, "")).resolves.toBeNull();
+        expect(mocks.retryWithNextAdapter).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/MusicPlayer.test.tsx
+++ b/src/components/MusicPlayer.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
     retryWithNextAdapter: vi.fn(),
     fetchTrackUrl: vi.fn<() => Promise<string | null>>(),
     capturedTrackFix: undefined as TrackFix | undefined,
+    capturedTrackPlayable: undefined as (() => void) | undefined,
     capturedEnabled: undefined as boolean | undefined,
 }));
 
@@ -33,8 +34,10 @@ vi.mock("../hooks/useOnlinePlayer", () => ({
         _autoPlay: boolean,
         enabled: boolean,
         onTrackFix?: TrackFix,
+        onTrackPlayable?: () => void,
     ) => {
         mocks.capturedTrackFix = onTrackFix;
+        mocks.capturedTrackPlayable = onTrackPlayable;
         mocks.capturedEnabled = enabled;
         return {
             currentSong: playlist[0],
@@ -67,6 +70,7 @@ const renderPlayer = () =>
 
 beforeEach(() => {
     mocks.capturedTrackFix = undefined;
+    mocks.capturedTrackPlayable = undefined;
     mocks.capturedEnabled = undefined;
     mocks.loading = false;
     mocks.retryWithNextAdapter.mockClear();
@@ -123,6 +127,32 @@ describe("MusicPlayer adapter downgrade path", () => {
 
         expect(mocks.fetchTrackUrl).toHaveBeenCalled();
         expect(mocks.retryWithNextAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not carry a stale failure across a track that played fine", async () => {
+        mocks.audioList = [
+            {
+                id: "",
+                name: "No id track",
+                artist: "Artist",
+                url: "https://example.test/opaque.mp3",
+                cover: "",
+                lrc: "",
+            },
+        ];
+
+        renderPlayer();
+
+        // 偶发的单曲失败：某首歌下架、某个链接坏掉
+        await mocks.capturedTrackFix?.(0, "https://example.test/opaque.mp3");
+
+        // 之后有曲目正常播放，说明数据源本身是好的
+        mocks.capturedTrackPlayable?.();
+
+        // 很久以后又有一首歌坏了——这不该被算作「连续」失败而整单换源
+        await mocks.capturedTrackFix?.(0, "https://example.test/opaque.mp3");
+
+        expect(mocks.retryWithNextAdapter).not.toHaveBeenCalled();
     });
 
     it("disables the audio player while a playlist refetch is in flight", () => {

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -7,9 +7,10 @@ import React, {
     useState,
 } from "react";
 import type { MusicConfig } from "../config/musicConfig";
+import { TRACK_FIX_FAILURE_LIMIT } from "../constants";
 import { type MusicTrack, useMusicData } from "../hooks/useMusicData";
 import { useOnlinePlayer } from "../hooks/useOnlinePlayer";
-import { Language } from "../types";
+import { Language, MusicDataError } from "../types";
 import { useTranslation } from "../utils/i18n";
 import { applyAnchoredPopoverPlacement } from "../utils/placeAnchoredPopover";
 import {
@@ -71,11 +72,28 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
             id: item.id,
             name: item.name,
             artist: item.artist,
-            url: (item.id && urlOverrides[item.id]) || item.url,
+            // 以原始 url 作为覆盖键：它必然存在且唯一，不依赖上游是否返回 id
+            url: urlOverrides[item.url] || item.url,
             cover: item.cover,
             lrc: item.lrc,
         }));
     }, [metingData, urlOverrides]);
+
+    /** 记录一次单曲回退失败；连续失败足够多次就整单切换数据源 */
+    const registerTrackFixFailure = useCallback((): null => {
+        errorCountRef.current += 1;
+
+        if (errorCountRef.current >= TRACK_FIX_FAILURE_LIMIT) {
+            console.warn(
+                "[MusicPlayer] Playlist playback failed consistently, switching to next API adapter for entire playlist...",
+            );
+            setUrlOverrides({});
+            retryWithNextAdapter();
+            errorCountRef.current = 0;
+        }
+
+        return null;
+    }, [retryWithNextAdapter]);
 
     const handleTrackFix = useCallback(
         async (index: number): Promise<string | null> => {
@@ -86,7 +104,13 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
             trackFixAbortRef.current = controller;
 
             const track = metingData[index];
-            if (!track || !track.id) return null;
+            if (!track) return null;
+
+            // 缺少 id/url 时无法做单曲回退，但这依然是一次播放失败：
+            // 必须计入，否则整单切换数据源的降级路径永远不会触发
+            if (!track.id || !track.url) {
+                return registerTrackFixFailure();
+            }
 
             const newUrl = await fetchTrackUrl(track.id, controller.signal);
 
@@ -96,7 +120,7 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
                 errorCountRef.current = 0;
                 setUrlOverrides((prev) => ({
                     ...prev,
-                    [track.id]: newUrl,
+                    [track.url]: newUrl,
                 }));
                 return newUrl;
             }
@@ -105,23 +129,19 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
                 `[MusicPlayer] Track fallback failed for: ${track.name}`,
             );
 
-            errorCountRef.current += 1;
-
-            if (errorCountRef.current >= 2) {
-                console.warn(
-                    "[MusicPlayer] Playlist playback failed consistently, switching to next API adapter for entire playlist...",
-                );
-                setUrlOverrides({});
-                retryWithNextAdapter();
-                errorCountRef.current = 0;
-            }
-
-            return null;
+            return registerTrackFixFailure();
         },
-        [metingData, fetchTrackUrl, retryWithNextAdapter],
+        [metingData, fetchTrackUrl, registerTrackFixFailure],
     );
 
-    const player = useOnlinePlayer(playlist, false, enabled, handleTrackFix);
+    // 切换适配器会重新拉取歌单，此时界面已切到 CONNECTING；
+    // 一并停掉音频，避免出现「显示正在连接、却还在播放旧数据源」的状态分裂
+    const player = useOnlinePlayer(
+        playlist,
+        false,
+        enabled && !dataLoading,
+        handleTrackFix,
+    );
 
     const applyPlaylistPlacement = useCallback(() => {
         const popover = popoverRef.current;
@@ -312,11 +332,20 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
     }
 
     if (dataError) {
+        // 歌单不存在/私密与服务故障是两回事，提示不同才能指导用户下一步
+        const isPlaylistProblem =
+            dataError === MusicDataError.PLAYLIST_UNAVAILABLE;
         return (
             <div className="flex flex-col items-center justify-center h-full text-red-500">
-                <i className="ri-error-warning-line icon-ui-xl mb-1"></i>
+                <i
+                    className={`${isPlaylistProblem ? "ri-play-list-line" : "ri-error-warning-line"} icon-ui-xl mb-1`}
+                ></i>
                 <div className="text-ui-xs font-ui-mono">
-                    {t("CONNECTION_LOST")}
+                    {t(
+                        isPlaylistProblem
+                            ? "PLAYLIST_UNAVAILABLE"
+                            : "CONNECTION_LOST",
+                    )}
                 </div>
             </div>
         );

--- a/src/components/MusicPlayer.tsx
+++ b/src/components/MusicPlayer.tsx
@@ -79,6 +79,12 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
         }));
     }, [metingData, urlOverrides]);
 
+    // 有曲目成功播放，说明数据源整体可用：清空计数，
+    // 使阈值只对「连续」失败生效，而不会把相隔很远的偶发失败累加成换源
+    const handleTrackPlayable = useCallback(() => {
+        errorCountRef.current = 0;
+    }, []);
+
     /** 记录一次单曲回退失败；连续失败足够多次就整单切换数据源 */
     const registerTrackFixFailure = useCallback((): null => {
         errorCountRef.current += 1;
@@ -141,6 +147,7 @@ const MusicPlayer: React.FC<MusicPlayerProps> = ({
         false,
         enabled && !dataLoading,
         handleTrackFix,
+        handleTrackPlayable,
     );
 
     const applyPlaylistPlacement = useCallback(() => {

--- a/src/config/musicConfig.ts
+++ b/src/config/musicConfig.ts
@@ -9,6 +9,23 @@ export interface MusicConfig {
 }
 
 /**
+ * 音乐数据源的唯一标识
+ *
+ * 同时用于：
+ * - useMusicData：数据源变化时重置适配器起始索引
+ * - AudioPlayer：作为 MusicPlayer 的 key，换歌单时重置播放器全部内部状态
+ */
+export const musicSourceKey = ({
+    server,
+    type,
+    id,
+}: {
+    server: string;
+    type: string;
+    id: string;
+}): string => `${server}|${type}|${id}`;
+
+/**
  * 默认音乐配置
  * 用于 App.tsx 中的 DEFAULT_SETTINGS
  */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,8 +56,14 @@ export const PRELOAD_DELAY_MS = 3000; // 预加载延迟时间（毫秒），避
 export const TIME_UPDATE_THROTTLE_SECONDS = 0.25; // 时间更新节流阈值（秒），减少频繁重渲染
 export const RESUME_TIME_BUFFER_SECONDS = 0.2; // 修复音轨后恢复播放时的时间回退缓冲（秒）
 export const API_FETCH_DELAY_MS = 100; // API 数据获取延迟（毫秒），减少初始加载卡顿
-export const API_TIMEOUT_MS = 5000; // API 请求超时时间（毫秒）
+// API 请求超时（毫秒）。适配器串行回退，最坏等待约为 API_FETCH_DELAY_MS + 各适配器超时之和。
+// 总预算约 6.1s，落在 RAIL / Nielsen 的 1–10s 可容忍区间内（超过 10s 用户倾向放弃）。
+// 预算向主源倾斜：主源数据新鲜，值得多等；备源实测 ~0.1s 返回，且数据可能陈旧，不必久候。
+export const API_TIMEOUT_MS = 3000; // 未指定超时的适配器所用的默认值
+export const PRIMARY_API_TIMEOUT_MS = 4000; // 主源实测 ~1.1s，留约 3.6 倍余量
+export const FALLBACK_API_TIMEOUT_MS = 2000; // 备源实测 ~0.1s，余量已极充裕
 export const ONLINE_CONSECUTIVE_ERROR_LIMIT = 5; // 在线播放连续加载失败达到该次数后停止自动切歌
+export const TRACK_FIX_FAILURE_LIMIT = 2; // 单曲回退连续失败达到该次数后，整单切换到下一个 API 适配器
 
 /**
  * 时间转换常量

--- a/src/hooks/useMusicData.test.ts
+++ b/src/hooks/useMusicData.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { API_FETCH_DELAY_MS } from "../constants";
+import { MusicDataError } from "../types";
 import type { MusicTrack } from "./useMusicData";
 import { useMusicData } from "./useMusicData";
 
@@ -15,14 +16,26 @@ const staleTracks: MusicTrack[] = [
     },
 ];
 
-vi.mock("../utils/musicApiAdapters", () => ({
-    getAdapters: () => [
-        {
-            buildUrl: () => "https://example.test/playlist",
-            parseResponse: (data: unknown) => data as MusicTrack[],
-        },
-    ],
-}));
+vi.mock("../utils/musicApiAdapters", async () => {
+    const actual = await vi.importActual<
+        typeof import("../utils/musicApiAdapters")
+    >("../utils/musicApiAdapters");
+    return {
+        ...actual,
+        // 保持真实的「主源 + 备源」两级结构，只替换请求地址；
+        // 解析仍走真实适配器，使错误分类测试覆盖 adapter → hook 的真实链路
+        getAdapters: () => [
+            {
+                buildUrl: () => "https://example.test/primary",
+                parseResponse: actual.metingAdapter.parseResponse,
+            },
+            {
+                buildUrl: () => "https://example.test/fallback",
+                parseResponse: actual.metingAdapter.parseResponse,
+            },
+        ],
+    };
+});
 
 afterEach(() => {
     vi.unstubAllGlobals();
@@ -69,5 +82,81 @@ describe("useMusicData", () => {
         });
 
         expect(result.current.audioList).toEqual([]);
+    });
+
+    it("reports an invalid playlist separately from a service outage", async () => {
+        vi.useFakeTimers();
+
+        // 上游对不存在的歌单同样返回 HTTP 200，内容为错误对象
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({
+                ok: true,
+                status: 200,
+                json: async () => ({ error: "unknown playlist id" }),
+            })),
+        );
+
+        const { result } = renderHook(() =>
+            useMusicData({ server: "netease", type: "playlist", id: "404" }),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(API_FETCH_DELAY_MS);
+        });
+
+        expect(result.current.error).toBe(MusicDataError.PLAYLIST_UNAVAILABLE);
+    });
+
+    it("stays conservative when one source fails and another reports an empty playlist", async () => {
+        vi.useFakeTimers();
+
+        // 第一次请求网络失败，第二次上游称歌单为空
+        let call = 0;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                call += 1;
+                if (call === 1) throw new TypeError("Failed to fetch");
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => [],
+                };
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useMusicData({ server: "netease", type: "playlist", id: "1" }),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(API_FETCH_DELAY_MS);
+        });
+
+        // 无法确定歌单本身有问题时，宁可提示服务故障（让用户重试），
+        // 也不要让用户去修改一个可能正确的歌单 ID
+        expect(result.current.error).toBe(MusicDataError.SERVICE_UNAVAILABLE);
+    });
+
+    it("reports a service outage when the request fails at the network layer", async () => {
+        vi.useFakeTimers();
+
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw new TypeError("Failed to fetch");
+            }),
+        );
+
+        const { result } = renderHook(() =>
+            useMusicData({ server: "netease", type: "playlist", id: "1" }),
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(API_FETCH_DELAY_MS);
+        });
+
+        expect(result.current.error).toBe(MusicDataError.SERVICE_UNAVAILABLE);
     });
 });

--- a/src/hooks/useMusicData.ts
+++ b/src/hooks/useMusicData.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { musicSourceKey } from "../config/musicConfig";
 import { API_FETCH_DELAY_MS } from "../constants";
+import { MusicDataError } from "../types";
 import { fetchWithTimeout, TimeoutError } from "../utils/fetchWithTimeout";
-import { getAdapters } from "../utils/musicApiAdapters";
+import { EmptyPlaylistError, getAdapters } from "../utils/musicApiAdapters";
 
 /**
  * 音乐曲目数据结构
@@ -50,7 +52,7 @@ const withoutSignal = (fetchOptions?: RequestInit): RequestInit => {
 export const useMusicData = ({ server, type, id }: UseMusicDataProps) => {
     const [audioList, setAudioList] = useState<MusicTrack[]>([]);
     const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const [error, setError] = useState<MusicDataError | null>(null);
     const [adapterStartIndex, setAdapterStartIndex] = useState(0);
     const [activeAdapterIndex, setActiveAdapterIndex] = useState<number | null>(
         null,
@@ -68,7 +70,7 @@ export const useMusicData = ({ server, type, id }: UseMusicDataProps) => {
 
     // 数据源变化时在渲染期间重置适配器起始索引
     // （React 官方 "adjusting state when props change" 模式，替代 effect 中的同步 setState）
-    const sourceKey = `${server}|${type}|${id}`;
+    const sourceKey = musicSourceKey({ server, type, id });
     const [prevSourceKey, setPrevSourceKey] = useState(sourceKey);
     if (prevSourceKey !== sourceKey) {
         setPrevSourceKey(sourceKey);
@@ -90,6 +92,10 @@ export const useMusicData = ({ server, type, id }: UseMusicDataProps) => {
             setActiveAdapterIndex(null);
 
             const adapters = getAdapters();
+            // 只有在没有任何数据源发生网络/超时/HTTP 失败时，才敢断言「歌单无效」。
+            // 混合失败（一源故障、另一源称歌单为空）会保守地归为服务问题：
+            // 误报服务问题只会让用户重试，而误报歌单无效会让用户去改一个本来正确的 ID。
+            let sawServiceFailure = false;
 
             for (let i = 0; i < adapters.length; i += 1) {
                 const adapterIndex = (adapterStartIndex + i) % adapters.length;
@@ -101,7 +107,10 @@ export const useMusicData = ({ server, type, id }: UseMusicDataProps) => {
                     const response = await fetchWithTimeout(
                         url,
                         withoutSignal(adapter.fetchOptions),
-                        { externalSignal: controller.signal },
+                        {
+                            externalSignal: controller.signal,
+                            timeoutMs: adapter.timeoutMs,
+                        },
                     );
 
                     if (!response.ok)
@@ -121,6 +130,11 @@ export const useMusicData = ({ server, type, id }: UseMusicDataProps) => {
                     if (controller.signal.aborted) {
                         return;
                     }
+                    // 上游以 200 表示歌单无效/为空：不是服务故障，继续问下一个源
+                    if (err instanceof EmptyPlaylistError) {
+                        continue;
+                    }
+                    sawServiceFailure = true;
                     // 超时或内部中止：尝试下一个适配器
                     if (
                         err instanceof TimeoutError ||
@@ -133,7 +147,11 @@ export const useMusicData = ({ server, type, id }: UseMusicDataProps) => {
                 }
             }
 
-            setError("All APIs failed");
+            setError(
+                sawServiceFailure
+                    ? MusicDataError.SERVICE_UNAVAILABLE
+                    : MusicDataError.PLAYLIST_UNAVAILABLE,
+            );
             setLoading(false);
         };
 
@@ -168,7 +186,10 @@ export const useMusicData = ({ server, type, id }: UseMusicDataProps) => {
                     const response = await fetchWithTimeout(
                         url,
                         withoutSignal(adapter.fetchOptions),
-                        { externalSignal: signal },
+                        {
+                            externalSignal: signal,
+                            timeoutMs: adapter.timeoutMs,
+                        },
                     );
 
                     if (!response.ok) continue;

--- a/src/hooks/useOnlinePlayer.test.ts
+++ b/src/hooks/useOnlinePlayer.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { STORAGE_KEYS } from "../constants";
+import { PlayMode } from "../types";
+import type { Song } from "./useOnlinePlayer";
+import { useOnlinePlayer } from "./useOnlinePlayer";
+
+const makePlaylist = (count: number, prefix: string): Song[] =>
+    Array.from({ length: count }, (_, index) => ({
+        id: `${prefix}-${index}`,
+        name: `${prefix} track ${index}`,
+        artist: "Artist",
+        url: `https://example.test/${prefix}/${index}.mp3`,
+        cover: "",
+        lrc: "",
+    }));
+
+beforeEach(() => {
+    localStorage.clear();
+    // 固定为顺序播放，避免随机起始索引干扰断言
+    localStorage.setItem(STORAGE_KEYS.AUDIO_PLAY_MODE, PlayMode.SEQUENCE);
+    vi.spyOn(window.HTMLMediaElement.prototype, "play").mockResolvedValue(
+        undefined,
+    );
+    vi.spyOn(window.HTMLMediaElement.prototype, "load").mockImplementation(
+        () => {},
+    );
+    vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(
+        () => {},
+    );
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("useOnlinePlayer playlist shrink", () => {
+    it("keeps a playable current song when the list shrinks below the current index", () => {
+        const { result, rerender } = renderHook(
+            ({ playlist }) => useOnlinePlayer(playlist, false, true),
+            { initialProps: { playlist: makePlaylist(86, "long") } },
+        );
+
+        act(() => {
+            result.current.playTrack(49, true);
+        });
+        expect(result.current.currentSong?.name).toBe("long track 49");
+
+        // 同一歌单来源下切换 API 适配器：列表变短但组件不会重建
+        rerender({ playlist: makePlaylist(10, "short") });
+
+        expect(result.current.currentSong).toBeDefined();
+        expect(result.current.currentSong?.url).toBeTruthy();
+    });
+
+    it("lands on the nearest valid position instead of jumping back to the start", () => {
+        const { result, rerender } = renderHook(
+            ({ playlist }) => useOnlinePlayer(playlist, false, true),
+            { initialProps: { playlist: makePlaylist(86, "long") } },
+        );
+
+        act(() => {
+            result.current.playTrack(49, true);
+        });
+
+        rerender({ playlist: makePlaylist(10, "short") });
+
+        // 适配器降级不是用户主动换歌单，应尽量少打扰：收敛到最近的合法位置而非回到开头
+        expect(result.current.currentIndex).toBe(9);
+        expect(result.current.currentSong?.name).toBe("short track 9");
+    });
+
+    it("leaves an in-range index untouched when the playlist only changes content", () => {
+        const { result, rerender } = renderHook(
+            ({ playlist }) => useOnlinePlayer(playlist, false, true),
+            { initialProps: { playlist: makePlaylist(86, "long") } },
+        );
+
+        act(() => {
+            result.current.playTrack(3, true);
+        });
+
+        rerender({ playlist: makePlaylist(86, "other") });
+
+        expect(result.current.currentIndex).toBe(3);
+        expect(result.current.currentSong?.name).toBe("other track 3");
+    });
+
+    it("still exposes no song for a genuinely empty playlist", () => {
+        const { result } = renderHook(() => useOnlinePlayer([], false, true));
+
+        expect(result.current.currentSong).toBeUndefined();
+    });
+});

--- a/src/hooks/useOnlinePlayer.test.ts
+++ b/src/hooks/useOnlinePlayer.test.ts
@@ -31,6 +31,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
 });
 
@@ -84,6 +85,39 @@ describe("useOnlinePlayer playlist shrink", () => {
 
         expect(result.current.currentIndex).toBe(3);
         expect(result.current.currentSong?.name).toBe("other track 3");
+    });
+
+    it("notifies the caller when a track becomes playable", () => {
+        const created: HTMLAudioElement[] = [];
+        const OriginalAudio = window.Audio;
+        vi.stubGlobal(
+            "Audio",
+            class extends OriginalAudio {
+                constructor(src?: string) {
+                    super(src);
+                    created.push(this);
+                }
+            },
+        );
+
+        const onTrackPlayable = vi.fn();
+        renderHook(() =>
+            useOnlinePlayer(
+                makePlaylist(3, "list"),
+                false,
+                true,
+                undefined,
+                onTrackPlayable,
+            ),
+        );
+
+        expect(created.length).toBeGreaterThan(0);
+
+        act(() => {
+            created[0].dispatchEvent(new Event("canplay"));
+        });
+
+        expect(onTrackPlayable).toHaveBeenCalled();
     });
 
     it("still exposes no song for a genuinely empty playlist", () => {

--- a/src/hooks/useOnlinePlayer.ts
+++ b/src/hooks/useOnlinePlayer.ts
@@ -26,6 +26,8 @@ export const useOnlinePlayer = (
     autoPlay: boolean = false,
     enabled: boolean = true,
     onTrackFix?: (index: number, currentUrl: string) => Promise<string | null>,
+    /** 曲目已可播放时触发，供调用方清空自己的连续失败计数 */
+    onTrackPlayable?: () => void,
 ) => {
     // 音频实例用 ref 持有；Swap 时递增 generation，驱动监听器/加载 effect 重跑
     const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -111,6 +113,12 @@ export const useOnlinePlayer = (
     useEffect(() => {
         onTrackFixRef.current = onTrackFix;
     }, [onTrackFix]);
+
+    const onTrackPlayableRef = useRef(onTrackPlayable);
+
+    useEffect(() => {
+        onTrackPlayableRef.current = onTrackPlayable;
+    }, [onTrackPlayable]);
 
     // 初始化随机索引逻辑
     const initializedRef = useRef(false);
@@ -202,6 +210,7 @@ export const useOnlinePlayer = (
             setIsLoading(false);
             setError(null); // Clear error on success
             consecutiveErrorsRef.current = 0; // 重置连续错误计数
+            onTrackPlayableRef.current?.();
             if (retryTimerRef.current !== null) {
                 clearTimeout(retryTimerRef.current);
                 retryTimerRef.current = null;

--- a/src/hooks/useOnlinePlayer.ts
+++ b/src/hooks/useOnlinePlayer.ts
@@ -134,6 +134,13 @@ export const useOnlinePlayer = (
         }
     }, [playlist.length, playMode]);
 
+    // 同一歌单来源下切换 API 适配器会换来长度不同的列表，此时 currentIndex 可能越界。
+    // 渲染期收敛到合法范围（React "adjusting state when props change"），
+    // 避免 currentSong 变成 undefined 而让 UI 误报「无信号」。
+    if (playlist.length > 0 && currentIndex > playlist.length - 1) {
+        setCurrentIndex(playlist.length - 1);
+    }
+
     // 使用提取的洗牌逻辑 Hook
     const { getNextRandomIndex, getPrevRandomIndex, peekNextRandomIndex } =
         useShuffle(playlist.length, playMode, currentIndex);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,15 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+/**
+ * 本仓库未开启 vitest 的 globals，RTL 因此不会自动注册 cleanup
+ * （它依赖全局 afterEach 存在）。在此统一兜底，避免每个测试文件各写一份，
+ * 也避免漏写导致组件/hook 实例跨用例存活。
+ */
+afterEach(() => {
+    cleanup();
+});
 
 /**
  * Node 22+/26 可能抢占全局 localStorage 名但未启用实现，

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,21 @@ export const PlayMode = {
 } as const;
 export type PlayMode = (typeof PlayMode)[keyof typeof PlayMode];
 
+/**
+ * 在线音乐数据获取的失败类别
+ *
+ * 上游对无效歌单同样返回 HTTP 200（`[]` 或 `{ error: ... }`），
+ * 因此必须按响应内容而非状态码区分这两种失败。
+ */
+export const MusicDataError = {
+    /** 所有数据源都表示该歌单不存在、私密或为空 */
+    PLAYLIST_UNAVAILABLE: "playlist-unavailable",
+    /** 至少一个数据源出现网络错误、超时或非 2xx 响应 */
+    SERVICE_UNAVAILABLE: "service-unavailable",
+} as const;
+export type MusicDataError =
+    (typeof MusicDataError)[keyof typeof MusicDataError];
+
 export const ThemePreset = {
     ORIGIN: "ORIGIN",
     ABYSSAL: "ABYSSAL",

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -42,6 +42,7 @@ export const translations = {
         ONLINE_STREAM: "ONLINE STREAM",
         CONNECTING: "CONNECTING TO SATELLITE...",
         CONNECTION_LOST: "CONNECTION LOST",
+        PLAYLIST_UNAVAILABLE: "PLAYLIST UNAVAILABLE",
         PLAYLIST_TITLE: "PLAYLIST",
 
         // Themes
@@ -183,6 +184,7 @@ export const translations = {
         ONLINE_STREAM: "在线流媒体",
         CONNECTING: "正在连接卫星信号...",
         CONNECTION_LOST: "连接丢失",
+        PLAYLIST_UNAVAILABLE: "歌单无效或为空",
         PLAYLIST_TITLE: "播放列表",
 
         // Themes

--- a/src/utils/musicApiAdapters.test.ts
+++ b/src/utils/musicApiAdapters.test.ts
@@ -1,5 +1,99 @@
 import { describe, expect, it } from "vitest";
-import { metingAdapter, metingFallbackAdapter } from "./musicApiAdapters";
+import {
+    EmptyPlaylistError,
+    getAdapters,
+    metingAdapter,
+    metingFallbackAdapter,
+} from "./musicApiAdapters";
+
+/**
+ * 以下载荷取自两个上游的真实响应（2026-08 实测）：
+ * 两者都不返回 id/song_id，歌曲 id 只存在于 url 的查询参数中。
+ */
+const injahowPlaylistItem = {
+    name: "ヨヅリナ - STUDY WITH MIKU ver. -",
+    artist: "STUDY WITH MIKU",
+    url: "https://api.injahow.cn/meting/?server=netease&type=url&id=3322640395",
+    pic: "https://api.injahow.cn/meting/?server=netease&type=pic&id=109951172354364941",
+    lrc: "https://api.injahow.cn/meting/?server=netease&type=lrc&id=3322640395",
+};
+
+const imetoPlaylistItem = {
+    title: "三日月ステップ - STUDY WITH MIKU ver. -",
+    author: "STUDY WITH MIKU",
+    url: "https://api.i-meto.com/meting/api?server=netease&type=url&id=3406945542&auth=23759078c5684352b4edf721eeacb436aca1a20e",
+    pic: "https://api.i-meto.com/meting/api?server=netease&type=pic&id=109951173564186500&auth=25a3dd358d47cf5d6a2f8421322022fb511ba364",
+    lrc: "https://api.i-meto.com/meting/api?server=netease&type=lrc&id=3406945542&auth=97371bf0cabce3d2495f77cbb71c8210f9aee568",
+};
+
+describe("track id recovery from real upstream payloads", () => {
+    it("recovers the song id from the injahow url when no id field is present", () => {
+        const [track] = metingFallbackAdapter.parseResponse([
+            injahowPlaylistItem,
+        ]);
+
+        expect(track.id).toBe("3322640395");
+        expect(track.name).toBe("ヨヅリナ - STUDY WITH MIKU ver. -");
+    });
+
+    it("recovers the song id from the i-meto signed url", () => {
+        const [track] = metingAdapter.parseResponse([imetoPlaylistItem]);
+
+        expect(track.id).toBe("3406945542");
+        expect(track.name).toBe("三日月ステップ - STUDY WITH MIKU ver. -");
+    });
+
+    it("prefers an explicit id field over the url derived one", () => {
+        const [track] = metingAdapter.parseResponse([
+            { ...injahowPlaylistItem, id: "explicit" },
+        ]);
+
+        expect(track.id).toBe("explicit");
+    });
+
+    it("yields an empty id rather than throwing on an unparsable url", () => {
+        const [track] = metingAdapter.parseResponse([
+            { name: "No url", artist: "A", url: "not-a-url" },
+        ]);
+
+        expect(track.id).toBe("");
+    });
+});
+
+describe("empty playlist is distinguishable from service failure", () => {
+    it("throws EmptyPlaylistError for the upstream 200 + error object", () => {
+        expect(() =>
+            metingFallbackAdapter.parseResponse({
+                error: "unknown playlist id",
+            }),
+        ).toThrow(EmptyPlaylistError);
+    });
+
+    it("throws EmptyPlaylistError for an empty array", () => {
+        expect(() => metingAdapter.parseResponse([])).toThrow(
+            EmptyPlaylistError,
+        );
+    });
+});
+
+describe("adapter priority", () => {
+    it("queries the documented primary API before the fallback", () => {
+        const [primary, fallback] = getAdapters();
+        const primaryUrl = primary.buildUrl({
+            server: "netease",
+            type: "playlist",
+            id: "1",
+        });
+        const fallbackUrl = fallback.buildUrl({
+            server: "netease",
+            type: "playlist",
+            id: "1",
+        });
+
+        expect(new URL(primaryUrl).hostname).toBe("api.i-meto.com");
+        expect(new URL(fallbackUrl).hostname).toBe("api.injahow.cn");
+    });
+});
 
 describe("metingAdapter.parseResponse", () => {
     it("maps primary fields", () => {

--- a/src/utils/musicApiAdapters.test.ts
+++ b/src/utils/musicApiAdapters.test.ts
@@ -7,8 +7,12 @@ import {
 } from "./musicApiAdapters";
 
 /**
- * 以下载荷取自两个上游的真实响应（2026-08 实测）：
+ * 以下载荷复刻两个上游真实响应的结构（2026-08 实测）：
  * 两者都不返回 id/song_id，歌曲 id 只存在于 url 的查询参数中。
+ *
+ * i-meto 会在 id 之后再附加一个签名参数，这个「id 不在末尾」的形状正是夹具要保住的
+ * 属性——它能挡住用贪婪正则截取 id 的错误实现。签名值本身不参与断言，
+ * 故用占位符代替真实签名（真实签名有时效，写死进仓库既无意义也会触发密钥扫描）。
  */
 const injahowPlaylistItem = {
     name: "ヨヅリナ - STUDY WITH MIKU ver. -",
@@ -21,9 +25,9 @@ const injahowPlaylistItem = {
 const imetoPlaylistItem = {
     title: "三日月ステップ - STUDY WITH MIKU ver. -",
     author: "STUDY WITH MIKU",
-    url: "https://api.i-meto.com/meting/api?server=netease&type=url&id=3406945542&auth=23759078c5684352b4edf721eeacb436aca1a20e",
-    pic: "https://api.i-meto.com/meting/api?server=netease&type=pic&id=109951173564186500&auth=25a3dd358d47cf5d6a2f8421322022fb511ba364",
-    lrc: "https://api.i-meto.com/meting/api?server=netease&type=lrc&id=3406945542&auth=97371bf0cabce3d2495f77cbb71c8210f9aee568",
+    url: "https://api.i-meto.com/meting/api?server=netease&type=url&id=3406945542&auth=placeholder-signature",
+    pic: "https://api.i-meto.com/meting/api?server=netease&type=pic&id=109951173564186500&auth=placeholder-signature",
+    lrc: "https://api.i-meto.com/meting/api?server=netease&type=lrc&id=3406945542&auth=placeholder-signature",
 };
 
 describe("track id recovery from real upstream payloads", () => {

--- a/src/utils/musicApiAdapters.ts
+++ b/src/utils/musicApiAdapters.ts
@@ -1,4 +1,21 @@
+import {
+    FALLBACK_API_TIMEOUT_MS,
+    MUSIC_API_BASE_URL,
+    MUSIC_API_FALLBACK_URL,
+    PRIMARY_API_TIMEOUT_MS,
+} from "../constants";
 import type { MusicTrack } from "../hooks/useMusicData";
+
+/**
+ * 上游以 HTTP 200 返回空数组或 `{ error: ... }` 时抛出。
+ * 与网络/超时/HTTP 错误区分开，使调用方能分辨「歌单无效」与「服务不可用」。
+ */
+export class EmptyPlaylistError extends Error {
+    constructor(message = "Empty playlist") {
+        super(message);
+        this.name = "EmptyPlaylistError";
+    }
+}
 
 /**
  * 音乐 API 适配器接口
@@ -24,6 +41,12 @@ export interface MusicAPIAdapter {
      * 可选的请求配置
      */
     fetchOptions?: RequestInit;
+
+    /**
+     * 该数据源的请求超时（毫秒）。省略时使用 API_TIMEOUT_MS。
+     * 各源的响应特征与数据价值不同，超时预算据此分配。
+     */
+    timeoutMs?: number;
 }
 
 const withQuery = (baseUrl: string, params: Record<string, string>): string => {
@@ -32,14 +55,27 @@ const withQuery = (baseUrl: string, params: Record<string, string>): string => {
 };
 
 /**
+ * 两个上游的歌单响应都不含 id/song_id 字段，歌曲 id 只存在于 url 的查询参数里
+ * （形如 `...?server=netease&type=url&id=<songId>`）。单曲级回退依赖该 id。
+ */
+const trackIdFromUrl = (url: unknown): string => {
+    if (typeof url !== "string" || url === "") return "";
+    try {
+        return new URL(url).searchParams.get("id") ?? "";
+    } catch {
+        return "";
+    }
+};
+
+/**
  * Meting API 适配器（主）
  */
 export const metingAdapter: MusicAPIAdapter = {
     buildUrl: ({ server, type, id }) =>
-        withQuery("https://api.i-meto.com/meting/api", { server, type, id }),
+        withQuery(MUSIC_API_BASE_URL, { server, type, id }),
 
     buildTrackUrl: ({ server, id }) =>
-        withQuery("https://api.i-meto.com/meting/api", {
+        withQuery(MUSIC_API_BASE_URL, {
             server,
             type: "song",
             id,
@@ -47,10 +83,10 @@ export const metingAdapter: MusicAPIAdapter = {
 
     parseResponse: (data) => {
         if (!Array.isArray(data) || data.length === 0) {
-            throw new Error("Empty playlist");
+            throw new EmptyPlaylistError();
         }
         return data.map((item: Record<string, string>) => ({
-            id: item.id || item.song_id || "", // Extract id
+            id: item.id || item.song_id || trackIdFromUrl(item.url),
             name: item.name || item.title || "Unknown Track",
             artist: item.artist || item.author || "Unknown Artist",
             url: item.url || "",
@@ -59,6 +95,8 @@ export const metingAdapter: MusicAPIAdapter = {
             theme: item.theme,
         }));
     },
+
+    timeoutMs: PRIMARY_API_TIMEOUT_MS,
 };
 
 /**
@@ -66,24 +104,30 @@ export const metingAdapter: MusicAPIAdapter = {
  */
 export const metingFallbackAdapter: MusicAPIAdapter = {
     buildUrl: ({ server, type, id }) =>
-        withQuery("https://api.injahow.cn/meting/", { server, type, id }),
+        withQuery(MUSIC_API_FALLBACK_URL, { server, type, id }),
 
     buildTrackUrl: ({ server, id }) =>
-        withQuery("https://api.injahow.cn/meting/", {
+        withQuery(MUSIC_API_FALLBACK_URL, {
             server,
             type: "song",
             id,
         }),
 
     parseResponse: metingAdapter.parseResponse,
+
+    timeoutMs: FALLBACK_API_TIMEOUT_MS,
 };
 
 /**
  * 获取当前启用的适配器列表
  * 按优先级排序，失败时会依次尝试下一个
  *
+ * 顺序遵循 constants.ts 声明的主/备契约：主源 i-meto 数据新鲜度更高，
+ * 备源 injahow 响应快但存在服务端长缓存（同一歌单会返回陈旧曲目），
+ * 仅在主源超时或失败时兜底。
+ *
  * 添加新 API 时，在此数组中添加对应的适配器即可
  */
 export const getAdapters = (): MusicAPIAdapter[] => {
-    return [metingFallbackAdapter, metingAdapter];
+    return [metingAdapter, metingFallbackAdapter];
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,6 +76,12 @@ export default defineConfig({
                             },
                         },
                     },
+                    // 两个音乐 API 都必须绕过缓存：歌单内容会变，且请求靠查询参数区分，
+                    // 而 ignoreURLParametersMatching 会忽略查询参数做匹配
+                    {
+                        urlPattern: /^https:\/\/api\.i-meto\.com\/meting\/.*/i,
+                        handler: "NetworkOnly",
+                    },
                     {
                         urlPattern: /^https:\/\/api\.injahow\.cn\/meting\/.*/i,
                         handler: "NetworkOnly",


### PR DESCRIPTION
- Add support for distinguishing between invalid playlists and service outages using new MusicDataError types.
- Implement track fallback logic in MusicPlayer to handle cases where track IDs are missing or invalid.
- Introduce a new musicSourceKey function to uniquely identify music sources for better state management.
- Update API timeout settings for improved performance and user experience.
- Add tests for music player behavior during adapter downgrades and error handling scenarios.

This commit improves the overall robustness of the music playback system and enhances error reporting for users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve online music playback robustness and clarity. We now distinguish invalid playlists from service outages, add per-track URL fallback with automatic adapter switching, and reset/pause the player correctly when sources change.

- **New Features**
  - Introduced `MusicDataError` to separate playlist-unavailable vs service-unavailable; UI shows specific message and icon.
  - Added per-track URL fix with song ID recovery from API URLs; successful playback clears the failure counter; after 2 consecutive failures, switch the whole playlist to the next adapter.
  - Added `musicSourceKey` to uniquely identify a source; used as `MusicPlayer` key and to reset adapter start index in `useMusicData`.
  - Reordered adapter priority to primary `api.i-meto.com` then fallback `api.injahow.cn`; added per-source timeouts; forced NetworkOnly in SW for both hosts to avoid stale caching.

- **Bug Fixes**
  - Missing/invalid track IDs now count toward failures so adapter downgrade always triggers when playback keeps failing.
  - Player disables during playlist refetch to avoid “connecting while still playing”.
  - When a playlist shrinks, current index clamps to the nearest valid track instead of jumping to start or exposing no song.
  - Track URL overrides keyed by original URL (not ID) so fallback works even when IDs are absent.

<sup>Written for commit 9032d384562f6952186061dcd8e24cf7ebb3baa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer messages for unavailable playlists versus service or connection failures.
  * Improved music source switching so playback resets correctly when the selected source changes.
  * Added support for recovering track information when playlist responses omit identifiers.

* **Bug Fixes**
  * Prevented playback during playlist loading and improved fallback handling when tracks fail.
  * Kept playback on a valid track when playlists shrink or become empty.
  * Improved music API timeout behavior and reduced delays when a source is unavailable.

* **Tests**
  * Expanded coverage for playlist errors, fallback behavior, track changes, and playback stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->