### PR TITLE
chore: stage 6 polish (task UUID, title i18n, stats semantics)

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -66,10 +66,10 @@
 - [ ] **#16 music-metadata 动态导入** —— `addFiles` 内 `await import("music-metadata")`，移出主包。*S*
 - [ ] **#31 Google Fonts 加载优化** —— CSS `@import` → index.html `preconnect` + `<link>`，或自托管字体。*S*
 - [ ] **#37 bundle 可视化 + 体积预算** —— 接入 rollup-plugin-visualizer，CI 加体积门禁。*S*
-- [ ] **#35 标题模式标签走 i18n** —— 新增 `MODE_BREAK_SHORT` 键替代内联三元。*S*
+- [x] **#35 标题模式标签走 i18n** —— 新增 `MODE_BREAK_SHORT` 键替代内联三元。*S*
 - [ ] **#32 keyframes 收敛** —— 重复 `scan` 及散落 `<style>` 统一迁入 index.css。*S*
-- [ ] **#28 后半 任务 id** —— `Date.now()` → `crypto.randomUUID()`。*S*
-- [ ] **#39 统计语义确认** —— sessionStorage vs localStorage 的"累计时长"语义，确认后写入 README/注释。*S*
+- [x] **#28 后半 任务 id** —— `Date.now()` → `crypto.randomUUID()`。*S*
+- [x] **#39 统计语义确认** —— sessionStorage vs localStorage 的"累计时长"语义，确认后写入 README/注释。*S*
 
 
 ## 专项（全部阶段之后）：统一消息系统

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import {
 import { getThemeExtraSpacing, useFooterHeight } from "./hooks/useFooterHeight";
 import { useSessionStats } from "./hooks/useSessionStats";
 import type { Settings } from "./types";
-import { Language, ThemePreset, TimerMode, View } from "./types";
+import { ThemePreset, TimerMode, View } from "./types";
 import { useTranslation } from "./utils/i18n";
 import {
     detectBrowserLanguage,
@@ -117,10 +117,10 @@ const App: React.FC = () => {
                 h > 0
                     ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
                     : `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-            // 休息时也显示模式标签（根据当前语言选择本地化短标签）
+            // 休息时也显示模式标签（短休/长休共用 MODE_BREAK_SHORT）
             const modeLabel =
                 remainingMode && remainingMode !== TimerMode.WORK
-                    ? ` ${settings.language === Language.CN ? "休息" : "Break"}`
+                    ? ` ${t("MODE_BREAK_SHORT")}`
                     : "";
             document.title = `${fmt}${modeLabel} • ${t("APP_TITLE")}`;
         } else {
@@ -134,7 +134,7 @@ const App: React.FC = () => {
             document.removeEventListener("visibilitychange", handleVisibility);
             restoreTitle();
         };
-    }, [isTimerRunning, remainingSeconds, remainingMode, t, settings.language]);
+    }, [isTimerRunning, remainingSeconds, remainingMode, t]);
 
     // 持久化设置
     useEffect(() => {

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -52,7 +52,7 @@ const TaskManager: React.FC<TaskManagerProps> = ({ language }) => {
         if (tasks.length >= MAX_TASKS) return;
 
         const newTask: Task = {
-            id: Date.now().toString(),
+            id: crypto.randomUUID(),
             text: inputValue.trim(),
             completed: false,
             createdAt: Date.now(),

--- a/src/hooks/useSessionStats.ts
+++ b/src/hooks/useSessionStats.ts
@@ -47,6 +47,10 @@ type UseSessionStatsResult = {
  * 3. 数据持久化（sessionStorage）
  * 4. 计时器状态同步
  *
+ * 存储语义（与 README「专注统计仅在当前标签页会话生效」一致）：
+ * - `SESSIONS` / `TOTAL_SECONDS` 使用 sessionStorage，关标签页即清空；
+ * - 不是跨天/跨设备累计；设置与任务仍走 localStorage。
+ *
  * @param workDuration 单个工作会话的设定时长（分钟）
  */
 export const useSessionStats = (

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -66,6 +66,8 @@ export const translations = {
         MODE_WORK: "OPERATIONAL",
         MODE_SHORT: "COOLDOWN",
         MODE_LONG: "HIBERNATION",
+        /** 隐藏标签页标题里短休/长休共用的短标签 */
+        MODE_BREAK_SHORT: "Break",
         STANDBY: "STANDBY",
         PAUSED_STATUS: "PAUSED",
         NOTIFICATION_WORK_COMPLETE_TITLE: "WORK CYCLE COMPLETE",
@@ -208,6 +210,8 @@ export const translations = {
         MODE_WORK: "作业中",
         MODE_SHORT: "冷却模式",
         MODE_LONG: "深度休眠",
+        /** 隐藏标签页标题里短休/长休共用的短标签 */
+        MODE_BREAK_SHORT: "休息",
         STANDBY: "待机中",
         PAUSED_STATUS: "已暂停",
         NOTIFICATION_WORK_COMPLETE_TITLE: "作业周期结束",


### PR DESCRIPTION
## Summary
- **#28** New task ids use `crypto.randomUUID()` (`createdAt` still `Date.now()`).
- **#35** Hidden-tab break title label uses i18n `MODE_BREAK_SHORT` (EN/CN) instead of an inline language ternary.
- **#39** Confirmed focus stats stay on `sessionStorage` (tab session); README already stated this — strengthened the `useSessionStats` comment.

## Why split
Stage 6 is split by risk. This PR is the low-risk polish batch only. Perf (`#16`/`#31`), render isolation (`#15`), CSS (`#32`), and bundle budget (`#37`) follow in later PRs.

## Behavior
- Task create/persist/load still uses string ids.
- Break title wording unchanged for users (`Break` / `休息`).
- No storage backend change for stats.

## Testing
- Automated: `pnpm lint`, `pnpm check`, `pnpm test` (83), `pnpm build` — pass.
- Manual: not run for title-when-hidden / add-task UUID (unverified in this session).
- Unverified: non-secure-context `crypto.randomUUID` (app is HTTPS/localhost PWA).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polish pass to align with Linear #28, #35, and #39: new tasks use `crypto.randomUUID()`, the hidden-tab break title is localized via `MODE_BREAK_SHORT`, and session stats are confirmed as session-scoped. No user-facing behavior changes or migrations.

- **Refactors**
  - Tasks: generate IDs with `crypto.randomUUID()`; `createdAt` still `Date.now()`.
  - Title i18n: replace inline ternary with `t("MODE_BREAK_SHORT")` for break label.
  - Stats: keep focus stats in `sessionStorage`; clarified comments and marked items done in docs.

<sup>Written for commit 8c58410d74b6d84fceaa91416adb26e673e02051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Break-mode browser tab titles now display the correct translated label in English and Chinese.
  * Task creation now uses more reliable unique identifiers, improving task handling without changing existing behavior.

* **Documentation**
  * Clarified how session statistics are stored, including tab-based clearing and daily/device limitations.
  * Updated optimization tracking to reflect completed work while preserving outstanding items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->