### PR TITLE
perf: stage 6 load path (music-metadata + Google Fonts)

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -63,8 +63,8 @@
 ## 阶段 6：性能与工程打磨
 
 - [ ] **#15 App 重渲染隔离** —— 时钟状态下沉到 HeaderBar 内部（或独立 Clock 组件）；`useTranslation` 返回用 `useCallback` 稳定化。*S*
-- [ ] **#16 music-metadata 动态导入** —— `addFiles` 内 `await import("music-metadata")`，移出主包。*S*
-- [ ] **#31 Google Fonts 加载优化** —— CSS `@import` → index.html `preconnect` + `<link>`，或自托管字体。*S*
+- [x] **#16 music-metadata 动态导入** —— `addFiles` 内 `await import("music-metadata")`，移出主包。*S*
+- [x] **#31 Google Fonts 加载优化** —— CSS `@import` → index.html `preconnect` + `<link>`，或自托管字体。*S*
 - [ ] **#37 bundle 可视化 + 体积预算** —— 接入 rollup-plugin-visualizer，CI 加体积门禁。*S*
 - [x] **#35 标题模式标签走 i18n** —— 新增 `MODE_BREAK_SHORT` 键替代内联三元。*S*
 - [ ] **#32 keyframes 收敛** —— 重复 `scan` 及散落 `<style>` 统一迁入 index.css。*S*

--- a/index.html
+++ b/index.html
@@ -15,6 +15,13 @@
   <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
   <!-- 图标 -->
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <!-- Google Fonts：preconnect + stylesheet，避免 CSS @import 阻塞首屏 -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Rajdhani:wght@500;600;700&display=swap"
+  />
   <!-- 提前加载全局样式，确保首屏就使用 src/index.css 中默认主题（已设置为 INDUSTRIAL） -->
   <link rel="stylesheet" href="/src/index.css" />
   <title>Endfield Protocol</title>

--- a/src/hooks/useLocalPlayer.ts
+++ b/src/hooks/useLocalPlayer.ts
@@ -1,4 +1,3 @@
-import { parseBlob } from "music-metadata";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DEFAULT_MUSIC_VOLUME } from "../config/musicConfig";
 import {
@@ -321,10 +320,11 @@ export const useLocalPlayer = (enabled: boolean = true) => {
             return updated;
         });
 
-        // 定义单个文件解析函数
+        // 定义单个文件解析函数（动态导入 music-metadata，避免进入首屏主包）
         const parseFile = async (file: File) => {
             const trackId = `${file.name}-${file.size}-${file.lastModified}`;
             try {
+                const { parseBlob } = await import("music-metadata");
                 const metadata = await parseBlob(file);
                 const title =
                     metadata.common.title || file.name.replace(/\.[^/.]+$/, "");

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Rajdhani:wght@500;600;700&display=swap');
-
 @import "tailwindcss";
 
 @theme {
-  /* 字体配置 */
+  /* 字体配置（字体 stylesheet 在 index.html 中 preconnect + link 加载） */
   --font-mono: "JetBrains Mono", monospace;
   --font-sans: "Rajdhani", sans-serif;
 


### PR DESCRIPTION
## Summary
- **#16** `music-metadata` is dynamically imported inside local `parseFile`, so it leaves the initial main JS chunk until users add local files.
- **#31** Google Fonts move from CSS `@import` to `index.html` `preconnect` + stylesheet `link` (same families/weights/`display=swap`).

## Behavior
- Local add-files still shows filename first, then upgrades title/artist/cover after metadata parse (first parse pays async chunk load).
- Online playback and other stage-6 items are unchanged.

## Measurement (same machine, `pnpm build`)
| | main index.js | gzip |
|---|---:|---:|
| Before | 429.70 kB | 131.89 kB |
| After | 333.30 kB | 103.10 kB |

Async chunk after: `core-*.js` ≈ 84.02 kB / gzip 25.36 kB (loaded on local metadata parse).

## Testing
- Automated: `pnpm lint`, `pnpm check`, `pnpm test` (85), `pnpm build` — pass.
- Artifact: built `dist/index.html` contains font preconnect/link; CSS no longer embeds fonts URL.
- Unverified in this session: visual FOUT on cold network; real device local-file metadata timing.

## Review
Pinpoint-review (single-reviewer) → CLEAR (0 blocker / 0 should-fix / 0 nit).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers `music-metadata` via dynamic import and switches Google Fonts from CSS `@import` to HTML preconnect + stylesheet to shrink the main bundle and speed first paint. Addresses Linear #16 and #31; main index bundle drops from 429.70 kB to 333.30 kB (gzip 131.89 kB → 103.10 kB), with the `music-metadata` chunk loaded only when users add local files.

<sup>Written for commit dd29b6e512ec308c0669b38c2e3034a499b55d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

