### PR TITLE
refactor: stage 6 render isolation + theme keyframes

### DIFF
--- a/docs/OPTIMIZATION_TODO.md
+++ b/docs/OPTIMIZATION_TODO.md
@@ -62,12 +62,12 @@
 
 ## 阶段 6：性能与工程打磨
 
-- [ ] **#15 App 重渲染隔离** —— 时钟状态下沉到 HeaderBar 内部（或独立 Clock 组件）；`useTranslation` 返回用 `useCallback` 稳定化。*S*
+- [x] **#15 App 重渲染隔离** —— 时钟状态下沉到 HeaderBar 内部独立 `HeaderClock`（`useTranslation` 的 `useCallback` 稳定化交由 React Compiler，不额外手写）。*S*
 - [x] **#16 music-metadata 动态导入** —— `addFiles` 内 `await import("music-metadata")`，移出主包。*S*
 - [x] **#31 Google Fonts 加载优化** —— CSS `@import` → index.html `preconnect` + `<link>`，或自托管字体。*S*
 - [ ] **#37 bundle 可视化 + 体积预算** —— 接入 rollup-plugin-visualizer，CI 加体积门禁。*S*
 - [x] **#35 标题模式标签走 i18n** —— 新增 `MODE_BREAK_SHORT` 键替代内联三元。*S*
-- [ ] **#32 keyframes 收敛** —— 重复 `scan` 及散落 `<style>` 统一迁入 index.css。*S*
+- [x] **#32 keyframes 收敛** —— 重复 `scan` 及散落 `<style>` 统一迁入 index.css。*S*
 - [x] **#28 后半 任务 id** —— `Date.now()` → `crypto.randomUUID()`。*S*
 - [x] **#39 统计语义确认** —— sessionStorage vs localStorage 的"累计时长"语义，确认后写入 README/注释。*S*
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,6 @@ const App: React.FC = () => {
     } = useSessionStats(settings.workDuration);
 
     const [currentView, setCurrentView] = useState<View>(View.DASHBOARD);
-    const [now, setNow] = useState(new Date());
     const [isOnline, setIsOnline] = useState(navigator.onLine);
 
     // Footer ref 和高度 - 用于 footer 元素和 Miku 装饰组件
@@ -163,8 +162,6 @@ const App: React.FC = () => {
     }, [settings.language]);
 
     useEffect(() => {
-        const timer = setInterval(() => setNow(new Date()), 1000);
-
         const handleOnline = () => setIsOnline(true);
         const handleOffline = () => setIsOnline(false);
 
@@ -172,7 +169,6 @@ const App: React.FC = () => {
         window.addEventListener("offline", handleOffline);
 
         return () => {
-            clearInterval(timer);
             window.removeEventListener("online", handleOnline);
             window.removeEventListener("offline", handleOffline);
         };
@@ -195,7 +191,6 @@ const App: React.FC = () => {
             <HeaderBar
                 currentView={currentView}
                 onViewChange={setCurrentView}
-                now={now}
                 isOnline={isOnline}
                 version={pkg.version}
                 t={t}

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -11,17 +11,37 @@ type HeaderBarProps = {
     t: ReturnType<typeof useTranslation>;
 };
 
-/** Wall clock isolated so App (and siblings) do not re-render every second. */
+/** Wall clock isolated so App (and siblings) do not re-render every second.
+ *  Interval runs only at Tailwind `md`+ — matches the previous `hidden md:flex` visibility. */
+const MD_UP_QUERY = "(min-width: 768px)";
+
 const HeaderClock: React.FC = () => {
     const [now, setNow] = useState(() => new Date());
+    const [isMdUp, setIsMdUp] = useState(
+        () => window.matchMedia(MD_UP_QUERY).matches,
+    );
 
     useEffect(() => {
-        const timer = window.setInterval(() => setNow(new Date()), 1000);
-        return () => window.clearInterval(timer);
+        const media = window.matchMedia(MD_UP_QUERY);
+        const onChange = () => {
+            const matches = media.matches;
+            setIsMdUp(matches);
+            if (matches) setNow(new Date());
+        };
+        media.addEventListener("change", onChange);
+        return () => media.removeEventListener("change", onChange);
     }, []);
 
+    useEffect(() => {
+        if (!isMdUp) return;
+        const timer = window.setInterval(() => setNow(new Date()), 1000);
+        return () => window.clearInterval(timer);
+    }, [isMdUp]);
+
+    if (!isMdUp) return null;
+
     return (
-        <div className="hidden md:flex flex-col items-end text-ui-micro font-ui-mono text-theme-dim border-l border-theme-highlight/30 pl-6">
+        <div className="flex flex-col items-end text-ui-micro font-ui-mono text-theme-dim border-l border-theme-highlight/30 pl-6">
             <span className="text-theme-primary text-ui-base leading-ui-none tracking-ui-widest">
                 {now.toLocaleTimeString("en-US", { hour12: false })}
             </span>

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { View } from "../types";
 import { useTranslation } from "../utils/i18n";
 import { Button } from "./ui";
@@ -6,16 +6,33 @@ import { Button } from "./ui";
 type HeaderBarProps = {
     currentView: View;
     onViewChange: (view: View) => void;
-    now: Date;
     isOnline: boolean;
     version: string;
     t: ReturnType<typeof useTranslation>;
 };
 
+/** Wall clock isolated so App (and siblings) do not re-render every second. */
+const HeaderClock: React.FC = () => {
+    const [now, setNow] = useState(() => new Date());
+
+    useEffect(() => {
+        const timer = window.setInterval(() => setNow(new Date()), 1000);
+        return () => window.clearInterval(timer);
+    }, []);
+
+    return (
+        <div className="hidden md:flex flex-col items-end text-ui-micro font-ui-mono text-theme-dim border-l border-theme-highlight/30 pl-6">
+            <span className="text-theme-primary text-ui-base leading-ui-none tracking-ui-widest">
+                {now.toLocaleTimeString("en-US", { hour12: false })}
+            </span>
+            <span className="opacity-70">{now.toLocaleDateString()}</span>
+        </div>
+    );
+};
+
 const HeaderBar: React.FC<HeaderBarProps> = ({
     currentView,
     onViewChange,
-    now,
     isOnline,
     version,
     t,
@@ -119,14 +136,7 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                         </Button>
                     </div>
 
-                    <div className="hidden md:flex flex-col items-end text-ui-micro font-ui-mono text-theme-dim border-l border-theme-highlight/30 pl-6">
-                        <span className="text-theme-primary text-ui-base leading-ui-none tracking-ui-widest">
-                            {now.toLocaleTimeString("en-US", { hour12: false })}
-                        </span>
-                        <span className="opacity-70">
-                            {now.toLocaleDateString()}
-                        </span>
-                    </div>
+                    <HeaderClock />
                 </div>
             </div>
         </header>

--- a/src/components/themes/BackgroundEffects.tsx
+++ b/src/components/themes/BackgroundEffects.tsx
@@ -38,42 +38,6 @@ export const AbyssalGrid = () => (
  */
 export const NeonGrid = () => (
     <>
-        <style>{`
-            @keyframes neon-grid-scroll {
-                0% { transform: translateY(0); }
-                100% { transform: translateY(40px); }
-            }
-            .synthwave-sun {
-                background: linear-gradient(180deg, #ffe53b 0%, #ff9800 45%, #ff5722 75%, #e91e63 100%);
-                mask-image: linear-gradient(
-                    to bottom,
-                    black 0%, black 50%, 
-                    transparent 50%, transparent 53%, 
-                    black 53%, black 60%, 
-                    transparent 60%, transparent 64%, 
-                    black 64%, black 70%, 
-                    transparent 70%, transparent 75%, 
-                    black 75%, black 80%, 
-                    transparent 80%, transparent 86%, 
-                    black 86%, black 90%, 
-                    transparent 90%, transparent 100%
-                );
-                -webkit-mask-image: linear-gradient(
-                    to bottom,
-                    black 0%, black 50%, 
-                    transparent 50%, transparent 53%, 
-                    black 53%, black 60%, 
-                    transparent 60%, transparent 64%, 
-                    black 64%, black 70%, 
-                    transparent 70%, transparent 75%, 
-                    black 75%, black 80%, 
-                    transparent 80%, transparent 86%, 
-                    black 86%, black 90%, 
-                    transparent 90%, transparent 100%
-                );
-            }
-        `}</style>
-
         {/* Synthwave 夕阳 */}
         <div className="absolute left-1/2 bottom-[10%] -translate-x-1/2 w-[240px] h-[240px] md:w-[320px] md:h-[320px] opacity-90 pointer-events-none">
             {/* 太阳本体带边缘模糊和内部发光 */}
@@ -175,7 +139,6 @@ export const MatrixRain = () => {
                     {col.chars}
                 </div>
             ))}
-            <style>{`@keyframes rain { 0% { transform: translateY(-100%); opacity: 0; } 10% { opacity: 1; } 90% { opacity: 1; } 100% { transform: translateY(100vh); opacity: 0; } }`}</style>
         </div>
     );
 };

--- a/src/components/themes/ForegroundEffects.tsx
+++ b/src/components/themes/ForegroundEffects.tsx
@@ -108,7 +108,6 @@ export const TacticalForeground: React.FC = () => {
 export const AbyssalForeground: React.FC = () => (
     <div className="fixed inset-0 pointer-events-none z-50">
         <div className="absolute top-0 left-0 w-full h-[5px] bg-theme-primary/20 blur-sm animate-[scan_3s_ease-in-out_infinite]"></div>
-        <style>{`@keyframes scan { 0% { transform: translateY(0); opacity: 0; } 50% { opacity: 1; } 100% { transform: translateY(100vh); opacity: 0; } }`}</style>
     </div>
 );
 
@@ -219,8 +218,6 @@ export const AzureForeground: React.FC = () => {
                 <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 -left-4"></div>
                 <div className="w-4 h-[1px] bg-theme-primary/30 absolute top-0 left-0"></div>
             </div>
-            {/* 扫描线 keyframes：同 Abyssal，top 布局动画改为合成器 transform */}
-            <style>{`@keyframes scan { 0% { transform: translateY(0); opacity: 0; } 50% { opacity: 1; } 100% { transform: translateY(100vh); opacity: 0; } }`}</style>
         </div>
     );
 };

--- a/src/components/themes/MikuDecorations.tsx
+++ b/src/components/themes/MikuDecorations.tsx
@@ -166,18 +166,6 @@ const MikuEqualizerBars = () => {
                     />
                 ))}
             </div>
-            <style>{`
-                @keyframes equalizer {
-                    0% { transform: scaleY(0.16); opacity: 0.3; }
-                    100% { transform: scaleY(1); opacity: 0.8; }
-                }
-                .animate-equalizer {
-                    height: 60%;
-                    transform-origin: bottom center;
-                    animation: equalizer 1s infinite ease-in-out alternate;
-                    animation-delay: calc(var(--bar-index) * -0.12s);
-                }
-            `}</style>
         </>
     );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -345,6 +345,102 @@ body {
   }
 }
 
+/* 主题装饰动画（原散落在组件内联 <style>） */
+@keyframes scan {
+  0% {
+    transform: translateY(0);
+    opacity: 0;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateY(100vh);
+    opacity: 0;
+  }
+}
+
+@keyframes neon-grid-scroll {
+  0% {
+    transform: translateY(0);
+  }
+
+  100% {
+    transform: translateY(40px);
+  }
+}
+
+@keyframes rain {
+  0% {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+
+  10% {
+    opacity: 1;
+  }
+
+  90% {
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateY(100vh);
+    opacity: 0;
+  }
+}
+
+@keyframes equalizer {
+  0% {
+    transform: scaleY(0.16);
+    opacity: 0.3;
+  }
+
+  100% {
+    transform: scaleY(1);
+    opacity: 0.8;
+  }
+}
+
+.animate-equalizer {
+  height: 60%;
+  transform-origin: bottom center;
+  animation: equalizer 1s infinite ease-in-out alternate;
+  animation-delay: calc(var(--bar-index) * -0.12s);
+}
+
+.synthwave-sun {
+  background: linear-gradient(180deg, #ffe53b 0%, #ff9800 45%, #ff5722 75%, #e91e63 100%);
+  mask-image: linear-gradient(
+    to bottom,
+    black 0%, black 50%,
+    transparent 50%, transparent 53%,
+    black 53%, black 60%,
+    transparent 60%, transparent 64%,
+    black 64%, black 70%,
+    transparent 70%, transparent 75%,
+    black 75%, black 80%,
+    transparent 80%, transparent 86%,
+    black 86%, black 90%,
+    transparent 90%, transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    black 0%, black 50%,
+    transparent 50%, transparent 53%,
+    black 53%, black 60%,
+    transparent 60%, transparent 64%,
+    black 64%, black 70%,
+    transparent 70%, transparent 75%,
+    black 75%, black 80%,
+    transparent 80%, transparent 86%,
+    black 86%, black 90%,
+    transparent 90%, transparent 100%
+  );
+}
+
 /* 流光效果 */
 .glow-conic-secondary {
   background: conic-gradient(from 0deg, transparent 0deg, transparent 60deg, var(--color-secondary) 180deg, transparent 300deg);


### PR DESCRIPTION
## Summary
- **#15** Wall clock lives in `HeaderClock` inside `HeaderBar`; `App` no longer owns `now` / a 1s interval. Hand-written `useCallback` for `useTranslation` skipped (React Compiler).
- **#32** Duplicate `scan` and scattered theme `<style>` blocks (`neon-grid-scroll`, `synthwave-sun`, `rain`, `equalizer`) moved into `src/index.css`.

## Behavior
- Header time/date still updates every second on desktop layout.
- Online/offline badge, view switching, and theme decorations preserved.
- Pomodoro/`onTick` still updates App while the timer runs (pre-existing; not part of this PR).

## Out of scope
- **#37** bundle visualizer + CI size budget (follow-up).

## Testing
- Automated: `pnpm lint`, `pnpm check`, `pnpm test` (85), `pnpm build` — pass.
- Unverified in this session: visual check of Neon / Matrix / Abyssal / Azure / Miku animations in browser.

## Review
Pinpoint-review (single-reviewer) → CLEAR.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the header wall clock to stop `App` from re-rendering every second, and centralized theme keyframes into `src/index.css`. The clock timer now only runs on `md`+ viewports to avoid hidden re-renders. Addresses #15 and #32.

- **Refactors**
  - Moved wall clock into `HeaderClock` inside `HeaderBar`; removed `now` state and 1s interval from `App`, and gated the timer with `(min-width: 768px)`.
  - Consolidated `scan`, `neon-grid-scroll`, `rain`, `equalizer`, and `.synthwave-sun` into `src/index.css`; removed inline `<style>` from theme components.

<sup>Written for commit c85923fc1ce6301e61373daa28346c0186cf885d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - The header clock now manages its own updates, keeping the displayed time and date current every second.
  - Online/offline status indicators continue to update as expected.
  - Theme animations and decorative effects continue to display consistently across neon grid, Matrix rain, scan-line, equalizer, and synthwave visuals.
  - Animation styling is now centralized for more consistent visual behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->