### PR TITLE
docs: improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # Endfield Pomodoro
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ChuwuYo/Endfield-Pomodoro)
@@ -59,7 +61,7 @@
 1. **克隆仓库**
    ```bash
    git clone https://github.com/ChuwuYo/Endfield-Pomodoro.git
-   cd endfield-pomodoro
+   cd Endfield-Pomodoro
    ```
 
 2. **安装依赖**


### PR DESCRIPTION
Makes one small, focused improvement to the existing README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the README setup command to use the correct directory name and improves Markdown spacing. Previously the instructions said "cd endfield-pomodoro"; now they say "cd Endfield-Pomodoro" to match the cloned folder.

- Prevents copy-paste errors on case-sensitive systems where the lowercase path would fail.
- Docs-only change; no code, build, or runtime impact.

<sup>Written for commit de4d7216a6fb74e0a0703be797d13b9725e64cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README formatting by adding spacing before the title.
  * Corrected the clone-directory command to use the repository’s proper name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->