### PR TITLE
feat: support deployment under a nested directory

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,8 +29,8 @@ export default defineConfig({
                 background_color: "#e5e5e5",
                 display: "standalone",
                 orientation: "any",
-                start_url: "/",
-                scope: "/",
+                start_url: "./",
+                scope: "./",
                 icons: [
                     {
                         src: "pwa-192x192.png",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import { VitePWA } from "vite-plugin-pwa";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    // 资源使用相对路径以支持可以和其他网站共存或存放于二级目录
+    base: "./",
     plugins: [
         react(),
         // @vitejs/plugin-react 6 移除了 babel 选项，


### PR DESCRIPTION
- Change vite base to "./" for relative path loading
- Allow the app to be deployed under any sub-path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Vite and PWA configuration to use relative paths, so the app can be deployed under a nested directory like `/subpath/` instead of only at the domain root.

- Sets `base: "./"` so built asset URLs are relative.
- Sets PWA `start_url` and `scope` to `"./"` so the manifest works from a subdirectory.

<sup>Written for commit bd961255e9b7508538c3a368281bb4ae4cee3aa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ChuwuYo/Endfield-Pomodoro/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment compatibility by allowing the app to run correctly from subdirectories or alongside other sites.
  * Updated asset loading and progressive web app navigation to use relative paths, helping prevent broken resources when the app is hosted outside the website root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->